### PR TITLE
Kakao OAuth with kakao's auth code, testing done

### DIFF
--- a/src/main/java/com/teamseven/MusicVillain/Dto/Converter/DtoConverterFactory.java
+++ b/src/main/java/com/teamseven/MusicVillain/Dto/Converter/DtoConverterFactory.java
@@ -12,7 +12,7 @@ public class DtoConverterFactory {
         if (sourceClass == Feed.class && targetClass == FeedDto.class) {
             return (DtoConverter<S, T>) new FeedDtoDtoConverter();
         } else if (sourceClass == Member.class && targetClass == MemberDto.class) {
-            return (DtoConverter<S, T>) new MemberDtoDtoConverter();
+            return (DtoConverter<S, T>) new MemberDtoConverter();
 //        } else if (sourceClass == Notification.class && targetClass == NotificationDto.class) {
 //            return (Converter<S, T>) new NotificationDtoConverter();
         } else {

--- a/src/main/java/com/teamseven/MusicVillain/Dto/Converter/MemberDtoConverter.java
+++ b/src/main/java/com/teamseven/MusicVillain/Dto/Converter/MemberDtoConverter.java
@@ -6,7 +6,7 @@ import com.teamseven.MusicVillain.Member.Member;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class MemberDtoDtoConverter implements DtoConverter<Member, MemberDto> {
+public class MemberDtoConverter implements DtoConverter<Member, MemberDto> {
 
     @Override
     public MemberDto convertToDto(Member memberEntity) {

--- a/src/main/java/com/teamseven/MusicVillain/Dto/MemberDto.java
+++ b/src/main/java/com/teamseven/MusicVillain/Dto/MemberDto.java
@@ -2,6 +2,7 @@ package com.teamseven.MusicVillain.Dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +15,8 @@ import java.util.List;
 
 @Builder
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+
 public class MemberDto implements DataTransferObject {
     @Schema(example = "uuid.toString()")
     public final String memberId; // PK, uuid.toString(), Never change after initialized

--- a/src/main/java/com/teamseven/MusicVillain/Dto/ResponseBody/ResponseObject.java
+++ b/src/main/java/com/teamseven/MusicVillain/Dto/ResponseBody/ResponseObject.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
@@ -63,6 +64,14 @@ public class ResponseObject extends ResponseEntity {
                 .message(message)
                 .data(data)
                 .build() ,HttpStatusCode.valueOf(status.getStatusCode()));
+    }
+
+    public ResponseObject(HttpHeaders headers, Status status, String message, Object data){
+        super(CustomResponseBody.builder()
+                .statusCode(status.getStatusCode())
+                .message(message)
+                .data(data)
+                .build(), headers, HttpStatusCode.valueOf(status.getStatusCode()));
     }
     /* ───────────────────────────────────────────────────────────────── */
 

--- a/src/main/java/com/teamseven/MusicVillain/Feed/FeedService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Feed/FeedService.java
@@ -203,7 +203,16 @@ public class FeedService {
      * @param feedType 조회할 피드의 타입
      * @return ServiceResult 객체. 성공시 해당 타입의 모든 FeedDto 객체의 리스트를 포함.
      */
+    /* WARN: test needed */
     public ServiceResult getAllFeedsByFeedType(String feedType){
+        if (feedType == null){
+            return ServiceResult.fail("feedType is null");
+        }
+
+        if(feedType.equals("all") || feedType.equals("전체")){
+            return this.getAllFeeds();
+        }
+
         List<Feed> feeds = feedRepository.findAllByFeedType(feedType);
         List<FeedDto> resultFeedDtoList = feedDtoDtoConverter.convertToDtoList(feeds);
         return ServiceResult.success(resultFeedDtoList);

--- a/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthController.java
@@ -1,5 +1,6 @@
 package com.teamseven.MusicVillain.Security.OAuth;
 
+import com.teamseven.MusicVillain.Dto.ResponseBody.CustomResponseBody;
 import com.teamseven.MusicVillain.Dto.ResponseBody.ResponseObject;
 import com.teamseven.MusicVillain.Dto.ResponseBody.Status;
 import com.teamseven.MusicVillain.Dto.ServiceResult;
@@ -7,8 +8,12 @@ import io.swagger.v3.oas.annotations.Hidden;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Hidden
 @RestController
@@ -21,9 +26,27 @@ public class OAuthController {
         this.oAuthService = oAuthService;
     }
 
+    /* DEBUG:
+         - description: for test
+         - requriements:
+            * need to change kakao redirect uri property(in `applicaiton.yml`) to "/oauth2/kakao/callback"
+            * need to register Redirect URI for "/oauth2/kakao/callback to Kakao's developers(myApp > kakao login > redirect URI)
+            * after test, need to change Kakao's redirect URI in com.teamseven.MusicVillain.Security.OAuth.OAuthService
+         - see:
+            * kakao developer's setting: https://developers.kakao.com*/
+    @GetMapping("/oauth2/kakao/callback")
+    public String catchKakaoAuthenticationCodeCallBack(@RequestParam("code") String code){
+        log.trace("> Enter catchKakaoAuthenticationCodeCallBack()");
+        log.trace("* code: {}", code);
+
+        return code;
+    }
+
     /* TODO: Test needed */
     @PostMapping("/oauth2/kakao/login")
-    public ResponseObject kakaoLogin(@RequestBody KakaoOAuthLoginRequestBody kakaoOAuthLoginRequestBody){
+    public ResponseEntity kakaoLogin(@RequestBody KakaoOAuthLoginRequestBody kakaoOAuthLoginRequestBody){
+        log.trace("> Enter kakaoLogin()\n"+
+                "\twith kakaoOAuthLoginRequestBody.code: {} ", kakaoOAuthLoginRequestBody.code);
 
         if(kakaoOAuthLoginRequestBody.code == null){
             return ResponseObject.of(Status.BAD_REQUEST,
@@ -32,8 +55,37 @@ public class OAuthController {
 
         ServiceResult kakaoOauthLoginResult = oAuthService.kakaoOauthLogin(kakaoOAuthLoginRequestBody.code);
 
-        return kakaoOauthLoginResult.isFailed() ? ResponseObject.of(
-                Status.AUTHENTICATION_FAIL, kakaoOauthLoginResult.getMessage(), null)
-                : ResponseObject.OK(kakaoOauthLoginResult.getData());
+        // if failed to login
+        if(kakaoOauthLoginResult.isFailed()) return ResponseObject.of(
+                Status.AUTHENTICATION_FAIL,
+                //kakaoOauthLoginResult.getMessage(),
+                Status.AUTHENTICATION_FAIL.getMessage(),
+                null);
+
+        // get ServiceResult's data and casting to Map
+        Map serviceResultData = (Map)kakaoOauthLoginResult.getData();
+
+        /* Not use header
+
+        // initialize HttpHeaders
+        HttpHeaders headers = new HttpHeaders();
+
+        // put access token to header(Authorization)
+        headers.add("Authorization",
+                "Bearer " + serviceResultData.get("accessToken").toString());
+
+        // put access token to header(Refresh)
+        headers.add("Refresh",
+                serviceResultData.get("refreshToken").toString());
+
+        // Response Rawdata = dto of logged-in member including accessToken and refreshToken in header
+        return new ResponseObject(headers, Status.OK,
+                kakaoOauthLoginResult.getMessage(),
+                serviceResultData.get("member"));
+        */
+
+        return ResponseObject.of(Status.OK,
+                 kakaoOauthLoginResult.getMessage(),
+                serviceResultData);
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,6 +9,8 @@
     <logger name ="com.teamseven.MusicVillain" level="DEBUG" />
 
 <!--    <logger name ="com.teamseven.MusicVillain.Member" level="INFO" />-->
+    <logger name ="com.teamseven.MusicVillain.Security.OAuth.OAuthController" level="TRACE" />
+    <logger name ="com.teamseven.MusicVillain.Security.OAuth.OAuthService" level="TRACE" />
 
     <logger name ="com.teamseven.MusicVillain.Member.MemberService" level="TRACE" />
     <root level="INFO">


### PR DESCRIPTION
> 카카오 인가코드를 통해 OAuth 로그인하는 기능 테스트 완료
+ 프론트가 현재 사용하는 URI로 Kakao OAuth Redirect URI가 설정되어 있는 상태에서, 프론트로부터 넘겨받은 카카오 인가코드를 통해 카카오에 해당 사용자에 대한 AccessToken을 요청하고 정보를 받아 JWT 토큰 생성 및 전달하는 과정 테스트 완료

> API 수정 사항
- 피드 카테고리별 조회하는 API에 RequestParam(feedType)으로 "all" 또는 "전체"가 들어올 경우 모든 피드 조회하도록 수정