### PR TITLE
테스트 코드 추가 및 일부 API 추가/변경

### DIFF
--- a/ERD.md
+++ b/ERD.md
@@ -1,0 +1,70 @@
+```mermaid
+erDiagram
+    member_table{
+        VARCHAR member_id PK "회원 식별자"
+        VARCHAR user_id "아이디"
+        VARCHAR user_info "비밀번호"
+        VARCHAR name "닉네임"
+        VARCHAR email "이메일"
+        VARCHAR role "권한"
+        DATETIME created_at "가입 시간"
+        DATETIME updated_at "최근 업데이트 시간"
+        DATETIME last_login_at "최근 로그인 시간"
+        VARCHAR provider_type "소셜 로그인 타입" 
+        }
+
+%%    member_table || -- o{ feed_table : "Member(1):Feed(N)"
+    feed_table{
+        VARCHAR feed_id PK "피드 식별자"
+        VARCHAR description "피드 설명"
+        VARCHAR owner_id FK "피드 소유자의 회원 식별자"
+        VARCHAR record_id FK "업로드된 음원 식별자"
+        VARCHAR feed_type "피드 유형"
+        INT view_count "조회수"
+        VARCHAR music_name "업로드한 음원 이름"
+        VARCHAR musician_name "업로드한 음원 아티스트"
+        DATETIME created_at "피드 생성 시간"
+        DATETIME updated_at "피드 업데이트 시간" 
+        }
+
+%%    token_table ||--|| member_table : "1:1"
+    token_table{
+        VARCHAR token_id PK "토큰 식별자"
+        VARCHAR owner_Id "소유자의 회원 식별자"
+        VARCHAR type "토큰 타입"
+        LONGTEXT value "토큰값"
+        DATETIME expired_at "토큰 만료 시간"
+    }
+
+%%    interaction_table }o -- o| member_table : ""  
+%%    interaction_table || -- o{ feed_table : ""
+    interaction_table{
+        String interation_id PK "인터렉션 식별자"
+        String owner_id FK "인터렉션을 수행한 회원의 식별자"
+        String feed_id FK "인터렉션 대상 피드의 식별자"
+    }
+
+%%    record_table || -- || feed_table : ""
+    record_table{
+        VARCHAR record_id PK "업로드된 음원 식별자"
+        VARCHAR record_filetype "음원 파일 타입"
+        INT record_filesize "음원 파일 크기"
+        INT record_duration "음원 길이(초 단위)"
+        LONGBLOB record_rawdata "음원 파일"
+    }
+
+%%    notification_table }o -- || member_table : ""
+    notification_table{
+        VARCHAR notification_id PK "알림 식별자"
+        VARCHAR owner_id FK "알림 소유자 식별자"
+        VARCHAR interation_id PK "인터렉션 식별자"
+        DATETIME created_at "알림 생성 시간"
+        VARCHAR owner_read "알림 소유자 읽음 여부"
+    }
+    
+    withdrawal_table{
+        VARCHAR withdrawal_id PK "제출된 탈퇴 사유 식별자"
+        VARCHAR reason "회원이 제출한 탈퇴 사유"
+        DATETIME created_at "탈퇴 사유가 생성된 시간"
+    }
+```

--- a/src/main/java/com/teamseven/MusicVillain/Configuration/WebMvcConfig.java
+++ b/src/main/java/com/teamseven/MusicVillain/Configuration/WebMvcConfig.java
@@ -13,7 +13,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOriginPatterns("*")  // 허용할 오리진들을 설정합니다. 여기서는 모든 오리진을 허용합니다.
-                .allowedMethods("GET", "POST", "PUT", "DELETE")  // 허용할 HTTP 메서드를 설정합니다.
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")  // 허용할 HTTP 메서드를 설정합니다.
                 .allowedHeaders("*")  // 허용할 헤더들을 설정합니다.
                 .allowCredentials(true);  // 쿠키를 허용합니다.
     }

--- a/src/main/java/com/teamseven/MusicVillain/Dto/RequestBody/InteractionCreationRequestBody.java
+++ b/src/main/java/com/teamseven/MusicVillain/Dto/RequestBody/InteractionCreationRequestBody.java
@@ -1,8 +1,10 @@
 package com.teamseven.MusicVillain.Dto.RequestBody;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class InteractionCreationRequestBody {
     public String feedId;
     public String memberId;

--- a/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
@@ -94,7 +94,7 @@ public class FeedController {
     }
 
     /**
-     * 피드 생성 | POST | /feeds?ownerId={ownerId}&musicName={musicName}&musicianName={musicianName}&feedType={feedType}&description={description}&recordDuration={recordDuration}&recordFile={recordFile}
+     * 피드 생성 | POST | /feeds
      * @apiNote 피드를 생성합니다.
      *
      * @author Woody K
@@ -144,6 +144,51 @@ public class FeedController {
         if (result.isFailed()) return ResponseObject.CREATION_FAIL(result.getData());
         log.trace("─> [FeedController] createFeed() finished");
         return ResponseObject.CREATED(result.getData());
+    }
+
+    /**
+     * 피드 내용 수정 | PUT | /feeds<br>
+     * @apiNote 피드 내용을 수정합니다.<br>
+     * - 수정하고자 하는 필드와 수정하려는 값(value)를 `form-data` 형태로 요청합니다.<br>
+     * - 피드 식별자(`feedId`)를 제외한 나머지 필드는 모두 선택적으로 수정할 수 있습니다.<br>
+     * - 수정하지 않는 필드의 경우 생략하여 `null`로 요청합니다.
+     * @see FeedService#modifyFeed(String, String, String, String, String, MultipartFile)
+     * @author Woody K
+     * @since JDK 17
+     * @param feedId 피드 식별자(수정 대상)
+     * @param feedType 수정하려는 피드 타입
+     * @param feedDescription 수정하려는 피드 설명
+     * @param musicName 수정하려는 음원명
+     * @param musicianName 수정하려는 가수명
+     * @param recordFile 수정하려는 파일 데이터
+     * @param headers JWT 토큰을 포함한 헤더
+     * @return [성공] 수정된 피드 정보 반환<br>[실패] 실패 메시지 반환
+     */
+    @PutMapping("/feeds")
+    public ResponseObject modifyFeed(@RequestParam(name = "feedId", required = true) String feedId,
+                                     @RequestParam(name = "feedType", required = false) String feedType,
+                                     @RequestParam(name = "description", required = false) String feedDescription,
+                                     @RequestParam(name = "musicName", required = false) String musicName,
+                                     @RequestParam(name = "musicianName", required = false) String musicianName,
+                                     @RequestParam(name = "recordFile",  required = false) MultipartFile recordFile,
+                                     @RequestHeader HttpHeaders headers){
+
+        AuthorizationResult authResult = feedAuthManager.authorize(headers, feedId);
+        if(authResult.isFailed())
+            return ResponseObject.UNAUTHORIZED(authResult.getMessage());
+
+        log.info("feedType: {}", feedType);
+        if(recordFile != null) {
+            log.info("recordFile.getSize(): {}", recordFile.getSize());
+            log.info("recordFile.getName(): {}", recordFile.getName());
+            log.info("recordFile.isEmpty(): {}", recordFile.isEmpty());
+        }
+
+        ServiceResult result = feedService.
+                modifyFeed(feedId, feedType, feedDescription, musicName, musicianName, recordFile);
+
+        return result.isFailed() ? ResponseObject.BAD_REQUEST(result.getData())
+                : ResponseObject.OK(result.getData());
     }
 
     /**

--- a/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-@Hidden
 @Slf4j
 @RestController
 @Tag(name = "피드 관련 API")

--- a/src/main/java/com/teamseven/MusicVillain/Feed/FeedService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Feed/FeedService.java
@@ -8,7 +8,7 @@ import com.teamseven.MusicVillain.Interaction.InteractionRepository;
 import com.teamseven.MusicVillain.Interaction.InteractionService;
 import com.teamseven.MusicVillain.Member.Member;
 import com.teamseven.MusicVillain.Member.MemberRepository;
-import com.teamseven.MusicVillain.Notification.NotificaitonRepository;
+import com.teamseven.MusicVillain.Notification.NotificationRepository;
 import com.teamseven.MusicVillain.Record.RecordRepository;
 import com.teamseven.MusicVillain.Dto.ResponseBody.RecordResponseBody;
 import com.teamseven.MusicVillain.Dto.ResponseBody.Status;
@@ -33,18 +33,18 @@ public class FeedService {
     private final InteractionRepository interactionRepository;
     private final RecordRepository recordRepository;
     private final MemberRepository memberRepository;
-    private final NotificaitonRepository notificaitonRepository;
+    private final NotificationRepository notificationRepository;
     private final InteractionService interactionService;
 
     @Autowired
     public FeedService(FeedRepository feedRepository, RecordRepository recordRepository,
                        MemberRepository memberRepository, InteractionRepository interactionRepository,
-                       NotificaitonRepository notificaitonRepository, InteractionService interactionService) {
+                       NotificationRepository notificationRepository, InteractionService interactionService) {
         this.feedRepository = feedRepository;
         this.recordRepository = recordRepository;
         this.memberRepository = memberRepository;
         this.interactionRepository = interactionRepository;
-        this.notificaitonRepository = notificaitonRepository;
+        this.notificationRepository = notificationRepository;
         this.interactionService = interactionService;
     }
 

--- a/src/main/java/com/teamseven/MusicVillain/Feed/FeedService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Feed/FeedService.java
@@ -75,12 +75,15 @@ public class FeedService {
      * @return RecordResponseBody 객체. 레코드의 세부 정보를 포함.
      */
     public RecordResponseBody getRecordByFeedId(String feedId){
-
+        if(feedId == null) return RecordResponseBody.builder()
+                .statusCode(Status.BAD_REQUEST.getStatusCode())
+                .message("FeedId is null")
+                .build();
         Feed feed = feedRepository.findByFeedId(feedId);
         if (feedRepository.findByFeedId(feedId) == null) return RecordResponseBody.builder()
-                    .statusCode(Status.NOT_FOUND.getStatusCode())
-                    .message("Feed not found")
-                    .build();
+                .statusCode(Status.NOT_FOUND.getStatusCode())
+                .message("Feed not found")
+                .build();
 
         return RecordResponseBody.builder()
                 .statusCode(Status.OK.getStatusCode())
@@ -110,7 +113,7 @@ public class FeedService {
      * @throws IOException 파일 처리 중 발생할 수 있는 예외
      */
     public ServiceResult insertFeed( String ownerId, String feedType, String feedDescription, int recordDuration, MultipartFile recordFile,
-                                    String musicName, String musicianName
+                                     String musicName, String musicianName
     ) throws IOException {
         log.debug("insertFeed() called");
         log.debug("- Parameters:");
@@ -189,7 +192,9 @@ public class FeedService {
      * @return ServiceResult 객체. 성공시 해당 멤버의 모든 FeedDto 객체의 리스트를 포함.
      */
     public ServiceResult getAllFeedsByMemberId(String memberId) {
+        if(memberId == null) return ServiceResult.fail("MemberId is null");
         List<Feed> feeds = feedRepository.findAllByOwnerMemberId(memberId);
+        if (feeds == null) return ServiceResult.fail("Feeds not found for memberId: " + memberId);
         List<FeedDto> resultFeedDtoList = feedDtoDtoConverter.convertToDtoList(feeds);
         return ServiceResult.success(resultFeedDtoList);
     }
@@ -206,7 +211,7 @@ public class FeedService {
     /* WARN: test needed */
     public ServiceResult getAllFeedsByFeedType(String feedType){
         if (feedType == null){
-            return ServiceResult.fail("feedType is null");
+            return ServiceResult.fail("FeedType is null");
         }
 
         if(feedType.equals("all") || feedType.equals("전체")){
@@ -214,6 +219,7 @@ public class FeedService {
         }
 
         List<Feed> feeds = feedRepository.findAllByFeedType(feedType);
+        if (feeds == null) return ServiceResult.fail("Feeds not found for feedType: " + feedType);
         List<FeedDto> resultFeedDtoList = feedDtoDtoConverter.convertToDtoList(feeds);
         return ServiceResult.success(resultFeedDtoList);
     }
@@ -228,6 +234,7 @@ public class FeedService {
      * @return ServiceResult 객체. 성공시 증가된 조회수를 포함.
      */
     public ServiceResult feedViewCountUp(String feedId){
+        if(feedId == null) return ServiceResult.fail("FeedId is null");
 
         Feed feed = feedRepository.findByFeedId(feedId);
 
@@ -251,13 +258,16 @@ public class FeedService {
     @Transactional
     public ServiceResult deleteFeedByFeedId(String feedId){
         // parameter null check
-        if(feedId == null)
+        if(feedId == null) {
+            log.debug("[!] deleteFeedByFeedId() failed: Bad request, feedId is null");
             return ServiceResult.fail("Bad request, feedId is null");
+        }
 
         System.out.println("Enter FeedService.deleteFeedByFeedId()");
         Feed nullableFeedToDelete = feedRepository.findByFeedId(feedId);
         // 존재하는 피드인지 확인
         if(nullableFeedToDelete == null){
+            log.debug("[!] deleteFeedByFeedId() failed: Feed Not Found");
             return ServiceResult.of(ServiceResult.FAIL, "Feed Not Found");}
 
         /* interactionService.deleteInterationsByFeedId에서
@@ -354,6 +364,7 @@ public class FeedService {
      */
     public ServiceResult getFeedOwnerMemberIdByFeedId(String feedId) {
         // check if
+        if (feedId == null) return ServiceResult.fail("FeedId is null");
 
         Feed nullableFeed = feedRepository.findByFeedId(feedId);
         if(nullableFeed == null) return ServiceResult.fail("Feed Not Found");

--- a/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-@Hidden
 @RestController
 public class InteractionController {
 

--- a/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionService.java
@@ -63,8 +63,6 @@ public class InteractionService {
      */
     @Transactional
     public ServiceResult insertInteraction(InteractionCreationRequestBody interactionCreationRequestBody){
-        // feed 테이블의 interaction_count도 증가시켜줘야함
-
         Member tmpMember = memberRepository.findByMemberId(interactionCreationRequestBody.getMemberId());
         Feed tmpFeed = feedRepository.findByFeedId(interactionCreationRequestBody.getFeedId());
         // 해당하는 멤버나 피드가 존재하는지 체크
@@ -118,11 +116,9 @@ public class InteractionService {
      */
     @Transactional
     public void deleteInteractionByInteractionId(String interactionId){
+        if (interactionId == null) return;
         Interaction targetInteraction = interactionRepository.findByInteractionId(interactionId);
-
-        // 해당 feed 의 interactionCount 를 1 감소시켜줌
-        Feed tmpFeed = feedRepository.findByFeedId(targetInteraction.getInteractionFeed().getFeedId());
-        feedRepository.save(tmpFeed);
+        if (targetInteraction == null) return;
 
         interactionRepository.deleteByInteractionId(interactionId);
     }
@@ -139,15 +135,17 @@ public class InteractionService {
     public void deleteInteractionByMemberId(String memberId){
         // deleteByInteractionMemberMemberId 로 한번에 삭제해버리면 안됨.
         // 각 인터렉션 아이디 얻어온 후, 인터렉션 아이디 하나 하나 삭제해주면서 해당 피드의 interactionCount 1 감소시켜줘야함
-
+        if (memberId == null) return;
+        Member tmpMember = memberRepository.findByMemberId(memberId);
+        if (tmpMember == null) return;
         List<Interaction> interactions = interactionRepository.findAll(); // 모든 Interaction 엔티티 가져오기
+        if (interactions == null) return;
         List<String> interactionIdListToDelete = interactions.stream()
                 .filter(interaction -> interaction.getInteractionMember().getMemberId().equals(memberId)) // memberId에 해당하는 Interaction 필터링
                 .map(Interaction::getInteractionId) // Interaction의 interaction_id 추출
                 .collect(Collectors.toList()); // 리스트에 추가
-
         for (String interactionId : interactionIdListToDelete) {
-           this.deleteInteractionByInteractionId(interactionId);
+            this.deleteInteractionByInteractionId(interactionId);
         }
 
     }
@@ -162,13 +160,15 @@ public class InteractionService {
      */
     @Transactional
     public void deleteInterationsByFeedId(String feedId) {
+        if (feedId == null) return;
+        Feed tmpFeed = feedRepository.findByFeedId(feedId);
+        if (tmpFeed == null) return;
         List<Interaction> interactionList = interactionRepository.findByInteractionFeedFeedId(feedId);
-
+        if (interactionList == null || interactionList.size()==0) return;
         //  notification 삭제
         for(Interaction i: interactionList){
             notificaitonRepository.deleteByInteraction(i);
         }
-
         // interaction 삭제
         interactionRepository.deleteByInteractionFeedFeedId(feedId);
 
@@ -184,7 +184,10 @@ public class InteractionService {
      * @return ServiceResult 객체. 성공시 피드에 연관된 인터랙션의 개수를 포함.
      */
     public ServiceResult getInteractionCountByFeedId(String feedId) {
-
+        if (feedId == null)
+            return ServiceResult.fail("Feed ID is null");
+        if (feedRepository.findByFeedId(feedId) == null)
+            return ServiceResult.fail("Feed not found");
         return ServiceResult.success(interactionRepository.countByInteractionFeedFeedId(feedId));
     }
 }

--- a/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionService.java
@@ -6,7 +6,7 @@ import com.teamseven.MusicVillain.Dto.RequestBody.InteractionCreationRequestBody
 import com.teamseven.MusicVillain.Member.Member;
 import com.teamseven.MusicVillain.Member.MemberRepository;
 import com.teamseven.MusicVillain.Dto.ServiceResult;
-import com.teamseven.MusicVillain.Notification.NotificaitonRepository;
+import com.teamseven.MusicVillain.Notification.NotificationRepository;
 import com.teamseven.MusicVillain.Notification.Notification;
 import com.teamseven.MusicVillain.Utils.RandomUUIDGenerator;
 import jakarta.transaction.Transactional;
@@ -24,18 +24,18 @@ public class InteractionService {
     private final InteractionRepository interactionRepository;
     private final MemberRepository memberRepository;
     private final FeedRepository feedRepository;
-    private final NotificaitonRepository notificaitonRepository;
+    private final NotificationRepository notificationRepository;
 
 
     @Autowired
     public InteractionService(InteractionRepository interactionRepository,
                               MemberRepository memberRepository, FeedRepository feedRepository,
-                              NotificaitonRepository notificaitonRepository){
+                              NotificationRepository notificationRepository){
 
         this.interactionRepository = interactionRepository;
         this.memberRepository = memberRepository;
         this.feedRepository = feedRepository;
-        this.notificaitonRepository = notificaitonRepository;
+        this.notificationRepository = notificationRepository;
     }
 
 
@@ -92,13 +92,13 @@ public class InteractionService {
                             .ownerRead(Notification.NOTIFICATION_UNREAD)
                             .createdAt(LocalDateTime.now())
                             .build();
-            notificaitonRepository.save(tmpNotification);
+            notificationRepository.save(tmpNotification);
 
             return ServiceResult.of(ServiceResult.SUCCESS, "Interaction created", generatedInteractionId);
         }
         else {
             // 관련 notificaiton 삭제
-            notificaitonRepository.deleteByInteraction(checkInteraction);
+            notificationRepository.deleteByInteraction(checkInteraction);
             // 인터렉션 삭제하여 좋아요 취소로 동작하도록 함.
             // 좋아요 취소로 동작
             interactionRepository.delete(checkInteraction);
@@ -167,7 +167,7 @@ public class InteractionService {
         if (interactionList == null || interactionList.size()==0) return;
         //  notification 삭제
         for(Interaction i: interactionList){
-            notificaitonRepository.deleteByInteraction(i);
+            notificationRepository.deleteByInteraction(i);
         }
         // interaction 삭제
         interactionRepository.deleteByInteractionFeedFeedId(feedId);

--- a/src/main/java/com/teamseven/MusicVillain/Member/MemberService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Member/MemberService.java
@@ -175,7 +175,7 @@ public class MemberService {
         nullableMember.setName(nickname);
         memberRepository.save(nullableMember);
 
-        return ServiceResult.success("nickname changed");
+        return ServiceResult.success("Nickname changed successfully");
     }
 
     /**

--- a/src/main/java/com/teamseven/MusicVillain/Notification/NotificationController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Notification/NotificationController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 import org.springframework.http.HttpHeaders;
 
-@Hidden
 @RestController
 @RequiredArgsConstructor
 public class NotificationController {

--- a/src/main/java/com/teamseven/MusicVillain/Notification/NotificationController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Notification/NotificationController.java
@@ -5,7 +5,6 @@ import com.teamseven.MusicVillain.Dto.ResponseBody.Status;
 import com.teamseven.MusicVillain.Dto.ServiceResult;
 import com.teamseven.MusicVillain.Security.JWT.AuthorizationResult;
 import com.teamseven.MusicVillain.Security.JWT.MemberJwtAuthorizationManager;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +16,7 @@ import org.springframework.http.HttpHeaders;
 public class NotificationController {
     private final NotificationService notificationService;
     private final MemberJwtAuthorizationManager memberAuthManager;
-    private final NotificaitonRepository notificaitonRepository;
+    private final NotificationRepository notificationRepository;
 
 
     /**
@@ -68,7 +67,7 @@ public class NotificationController {
         /* TODO: Refactoring later */
         if(notificationId == null) return ResponseObject.BAD_REQUEST("notificationId is null");
 
-        Notification notification = notificaitonRepository.findByNotificationId(notificationId);
+        Notification notification = notificationRepository.findByNotificationId(notificationId);
         if(notification == null) return ResponseObject.BAD_REQUEST("notification not found");
         AuthorizationResult authResult = memberAuthManager.authorize(headers, notification.getOwner().memberId);
 

--- a/src/main/java/com/teamseven/MusicVillain/Notification/NotificationRepository.java
+++ b/src/main/java/com/teamseven/MusicVillain/Notification/NotificationRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface NotificaitonRepository extends JpaRepository<Notification, String> {
+public interface NotificationRepository extends JpaRepository<Notification, String> {
 
     List<Notification> findAll();;
     Notification findByNotificationId(String notificationId);

--- a/src/main/java/com/teamseven/MusicVillain/Notification/NotificationService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Notification/NotificationService.java
@@ -4,23 +4,17 @@ import com.teamseven.MusicVillain.Dto.NotificationDto;
 import com.teamseven.MusicVillain.Dto.ServiceResult;
 import com.teamseven.MusicVillain.Member.Member;
 import com.teamseven.MusicVillain.Member.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class NotificationService {
 
     private final MemberRepository memberRepository;
-    private final NotificaitonRepository notificaitonRepository;
-
-    @Autowired
-    public NotificationService(NotificaitonRepository notificaitonRepository,
-                               MemberRepository memberRepository){
-        this.notificaitonRepository = notificaitonRepository;
-        this.memberRepository = memberRepository;
-    }
+    private final NotificationRepository notificationRepository;
 
     /**
      * 특정 회원의 모든 알림을 가져옵니다.
@@ -34,7 +28,8 @@ public class NotificationService {
     public ServiceResult getNotificaitonsByOwnerMemberID(String memberId){
         Member tmpMember =memberRepository.findByMemberId(memberId);
         if (tmpMember == null) return ServiceResult.fail("Member not found");
-        List<Notification> notifications = notificaitonRepository.findByOwnerMemberId(memberId);
+        List<Notification> notifications = notificationRepository.findByOwnerMemberId(memberId);
+        if (notifications == null || notifications.isEmpty()) return ServiceResult.fail("Notification not found");
         return ServiceResult.success( NotificationDto.toDtoList(notifications));
     }
 
@@ -48,13 +43,13 @@ public class NotificationService {
      * @return ServiceResult 객체. 성공 또는 실패 메시지를 포함.
      */
     public ServiceResult readNotification(String notificationId){
-        Notification tmpNotification = notificaitonRepository.findByNotificationId(notificationId);
+        Notification tmpNotification = notificationRepository.findByNotificationId(notificationId);
         if (tmpNotification == null) return ServiceResult.fail("Notification not found");
         if (tmpNotification.ownerRead.equals(Notification.NOTIFICATION_READ))
             return ServiceResult.fail("Notification already read");
 
         tmpNotification.ownerRead = Notification.NOTIFICATION_READ;
-        notificaitonRepository.save(tmpNotification);
+        notificationRepository.save(tmpNotification);
         return ServiceResult.success("Notification read successfully");
     }
 }

--- a/src/main/java/com/teamseven/MusicVillain/Record/RecordController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Record/RecordController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-@Hidden
 @RestController
 public class RecordController {
     private final RecordService recordService;

--- a/src/main/java/com/teamseven/MusicVillain/Record/RecordService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Record/RecordService.java
@@ -1,16 +1,13 @@
 package com.teamseven.MusicVillain.Record;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.List;
 @Service
+@RequiredArgsConstructor
 public class RecordService {
     private final RecordRepository recordRepository;
-
-    @Autowired
-    public RecordService(RecordRepository recordRepository){
-        this.recordRepository = recordRepository;
-    }
 
     /**
      * 모든 Record 객체를 반환합니다.
@@ -33,6 +30,9 @@ public class RecordService {
      * @param recordId 삭제할 Record의 아이디
      */
     public void DeleteRecordByRecordId(String recordId){
+        if (recordRepository.findByRecordId(recordId) == null) {
+            throw new IllegalArgumentException("Record Not Found.");
+        }
         recordRepository.deleteByRecordId(recordId);
     }
 }

--- a/src/main/java/com/teamseven/MusicVillain/Security/OAuth/KakaoOAuthLoginRequestBody.java
+++ b/src/main/java/com/teamseven/MusicVillain/Security/OAuth/KakaoOAuthLoginRequestBody.java
@@ -2,5 +2,5 @@ package com.teamseven.MusicVillain.Security.OAuth;
 
 public class KakaoOAuthLoginRequestBody {
     public String code; // Kakao's Authorization Code
-
+    public String redirectUri; // 카카오 코드를 받은 Redirect URI
 }

--- a/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthController.java
@@ -84,7 +84,8 @@ public class OAuthController {
                     "Kakao authorization code is null", null);
         }
 
-        ServiceResult kakaoOauthLoginResult = oAuthService.kakaoOauthLogin(kakaoOAuthLoginRequestBody.code);
+        ServiceResult kakaoOauthLoginResult = oAuthService.kakaoOauthLogin(kakaoOAuthLoginRequestBody.code,
+                kakaoOAuthLoginRequestBody.redirectUri);
 
         // if failed to login
         if(kakaoOauthLoginResult.isFailed()) return ResponseObject.onlyData(

--- a/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthService.java
@@ -41,7 +41,7 @@ public class OAuthService {
     private final JwtTokenRepository jwtTokenRepository;
 
     /* Kakao REST API reference: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api */
-    public ServiceResult getKakaoAccessTokenByKakaoAuthorizationCode(String kakaoAuthorizationCode) {
+    public ServiceResult getKakaoAccessTokenByKakaoAuthorizationCode(String kakaoAuthorizationCode, String redirectUri) {
         log.trace("> Enter getKakaoAccessTokenByKakaoAuthorizationCode()\n"+
                 "\t-with kakaoAuthorizationCode: {}",kakaoAuthorizationCode);
 
@@ -68,7 +68,7 @@ public class OAuthService {
             StringBuilder sb = new StringBuilder();
             sb.append("grant_type=authorization_code");
             sb.append("&client_id=" + ENV.KAKAO_CLIENT_ID); // client_id = REST API Key
-            sb.append("&redirect_uri=http://localhost:3000/kakaoredirect"); // 인가코드를 받은 redirect URI
+            sb.append("&redirect_uri=" + redirectUri); // 인가코드를 받은 redirect URI
             sb.append("&code=" + kakaoAuthorizationCode);
             bw.write(sb.toString());
             bw.flush();
@@ -321,14 +321,15 @@ public class OAuthService {
     }
 
     /* WARN: test needed */
-    public ServiceResult kakaoOauthLogin(String kakaoAuthorizationCode){
+    public ServiceResult kakaoOauthLogin(String kakaoAuthorizationCode, String redirectUri){
         log.trace("> Enter KakaoOauthLogin()\n"
                 +"\t-with kakaoAuthorizationCode: {}", kakaoAuthorizationCode);
 
         log.trace("kakaoOauthLogin -> get kakaoAccessToken using kakaoAuthorizationCode");
         // get kakaoAccessToken using kakaoAuthorizationCode
         ServiceResult accessTokenServiceResult
-                = this.getKakaoAccessTokenByKakaoAuthorizationCode(kakaoAuthorizationCode);
+                = this.getKakaoAccessTokenByKakaoAuthorizationCode
+                (kakaoAuthorizationCode,redirectUri);
 
         // check if kakaoMemberIdServiceResult is failed
         if (accessTokenServiceResult.isFailed()){

--- a/src/main/java/com/teamseven/MusicVillain/View/DatabaseViewContorller.java
+++ b/src/main/java/com/teamseven/MusicVillain/View/DatabaseViewContorller.java
@@ -8,7 +8,7 @@ import com.teamseven.MusicVillain.Interaction.InteractionService;
 import com.teamseven.MusicVillain.Member.Member;
 import com.teamseven.MusicVillain.Member.MemberRepository;
 import com.teamseven.MusicVillain.Member.MemberService;
-import com.teamseven.MusicVillain.Notification.NotificaitonRepository;
+import com.teamseven.MusicVillain.Notification.NotificationRepository;
 import com.teamseven.MusicVillain.Notification.Notification;
 import com.teamseven.MusicVillain.Record.Record;
 import com.teamseven.MusicVillain.Record.RecordService;
@@ -27,19 +27,19 @@ public class DatabaseViewContorller {
     private final FeedRepository feedRepository;
     private final RecordService recordService;
     private final InteractionService interactionService;
-    private final NotificaitonRepository notificaitonRepository;
+    private final NotificationRepository notificationRepository;
 
     @Autowired
     public DatabaseViewContorller(MemberService memberService, FeedService feedService,
                                   RecordService recordService, InteractionService interactionService,
-                                  FeedRepository feedRepository, NotificaitonRepository notificaitonRepository,
+                                  FeedRepository feedRepository, NotificationRepository notificationRepository,
                                   MemberRepository memberRepository) {
         this.memberService = memberService;
         this.feedService = feedService;
         this.recordService = recordService;
         this.interactionService = interactionService;
         this.feedRepository = feedRepository;
-        this.notificaitonRepository = notificaitonRepository;
+        this.notificationRepository = notificationRepository;
         this.memberRepository = memberRepository;
 
     }
@@ -73,7 +73,7 @@ public class DatabaseViewContorller {
     }
     @GetMapping("/view/notifications")
     public String notificationsView(Model model){
-        List<Notification> notificationList = notificaitonRepository.findAll();
+        List<Notification> notificationList = notificationRepository.findAll();
         model.addAttribute("notificationList", notificationList);
         return "notification_view";
     }

--- a/src/test/java/com/teamseven/MusicVillain/FeedServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/FeedServiceUnitTest.java
@@ -1,15 +1,16 @@
 package com.teamseven.MusicVillain;
 
-import com.teamseven.MusicVillain.Dto.Converter.DtoConverter;
-import com.teamseven.MusicVillain.Dto.Converter.FeedDtoDtoConverter;
 import com.teamseven.MusicVillain.Dto.DataTransferObject;
 import com.teamseven.MusicVillain.Dto.FeedDto;
 import com.teamseven.MusicVillain.Dto.ResponseBody.RecordResponseBody;
+import com.teamseven.MusicVillain.Dto.ResponseBody.Status;
 import com.teamseven.MusicVillain.Dto.ServiceResult;
 import com.teamseven.MusicVillain.Feed.Feed;
 import com.teamseven.MusicVillain.Feed.FeedRepository;
+import com.teamseven.MusicVillain.Interaction.InteractionService;
 import com.teamseven.MusicVillain.Member.Member;
 import com.teamseven.MusicVillain.Member.MemberRepository;
+import com.teamseven.MusicVillain.Record.Record;
 import com.teamseven.MusicVillain.Record.RecordRepository;
 import com.teamseven.MusicVillain.Security.JWT.JwtTokenRepository;
 import com.teamseven.MusicVillain.Feed.FeedService;
@@ -21,7 +22,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -45,132 +45,139 @@ public class FeedServiceUnitTest {
     @Mock
     JwtTokenRepository mockJwtTokenRepository;
 
-    @InjectMocks
-    FeedService feedService;
+    @Mock
+    InteractionService mockInteractionService;
 
+    @InjectMocks
+    FeedService mockFeedService;
 
     @Nested
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @DisplayName("Create 테스트 (insertFeed)")
+    @DisplayName("Create 테스트")
     class CreateTest{
-        @Test
-        @Order(1)
-        @DisplayName("정상적인 요청의 경우 동일한 정보를 가진 피드가 생성되어야 한다.")
-        void createFeedTest() throws IOException {
-            // given
-            String mockOwnerId = "mockOwnerId";
-            String mockFeedType = "mockFeedType";
-            String mockFeedDescription = "mockFeedDescription";
-            int mockRecordDuration = 100;
-            MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
-            String mockMusicName = "mockMusicName";
-            String mockMusicianName = "mockMusicianName";
-            Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(Member.builder().memberId(mockOwnerId).build());
-            Mockito.when(mockRecordRepository.save(Mockito.any())).thenReturn(null);
-            Mockito.when(mockFeedRepository.save(Mockito.any())).thenReturn(null);
+        @Nested
+        @DisplayName("insertFeed")
+        class InsertFeed{
+            @Test
+            @Order(1)
+            @DisplayName("정상적인 요청의 경우 동일한 정보를 가진 피드가 생성되어야 한다.")
+            void createFeedTest() throws IOException {
+                // given
+                String mockOwnerId = "mockOwnerId";
+                String mockFeedType = "mockFeedType";
+                String mockFeedDescription = "mockFeedDescription";
+                int mockRecordDuration = 100;
+                MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
+                String mockMusicName = "mockMusicName";
+                String mockMusicianName = "mockMusicianName";
+                Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(Member.builder().memberId(mockOwnerId).build());
+                Mockito.when(mockRecordRepository.save(Mockito.any())).thenReturn(null);
+                Mockito.when(mockFeedRepository.save(Mockito.any())).thenReturn(null);
 
-            // when
-            ServiceResult serviceResult = feedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
+                // when
+                ServiceResult serviceResult = mockFeedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
 
-            // then
-            String createdFeed = (String) serviceResult.getData();
+                // then
+                String createdFeed = (String) serviceResult.getData();
 
-            Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
-            Mockito.verify(mockRecordRepository, Mockito.times(1)).save(Mockito.any());
-            Mockito.verify(mockFeedRepository, Mockito.times(1)).save(Mockito.any());
+                Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
+                Mockito.verify(mockRecordRepository, Mockito.times(1)).save(Mockito.any());
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).save(Mockito.any());
 
-            Assertions.assertEquals(serviceResult.getResult(), ServiceResult.SUCCESS);
+                Assertions.assertEquals(serviceResult.getResult(), ServiceResult.SUCCESS);
 
-        }
+            }
 
-        @Test
-        @Order(2)
-        @DisplayName("필요한 인자가 누락된 경우 생성되지 않아야 한다. - `ownerId` 누락")
-        public void createFeedTestWithOwnerIdNull() throws IOException{
-            // given
-            String mockOwnerId = null;
-            String mockFeedType = "mockFeedType";
-            String mockFeedDescription = "mockFeedDescription";
-            int mockRecordDuration = 100;
-            MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
-            String mockMusicName = "mockMusicName";
-            String mockMusicianName = "mockMusicianName";
-            Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(null);
+            @Test
+            @Order(2)
+            @DisplayName("필요한 인자가 누락된 경우 생성되지 않아야 한다. - `ownerId` 누락")
+            public void createFeedTestWithOwnerIdNull() throws IOException{
+                // given
+                String mockOwnerId = null;
+                String mockFeedType = "mockFeedType";
+                String mockFeedDescription = "mockFeedDescription";
+                int mockRecordDuration = 100;
+                MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
+                String mockMusicName = "mockMusicName";
+                String mockMusicianName = "mockMusicianName";
+                Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(null);
 
-            // when
-            ServiceResult serviceResult = feedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
+                // when
+                ServiceResult serviceResult = mockFeedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
 
-            // then
-            Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
-            Mockito.verify(mockRecordRepository, Mockito.times(0)).save(Mockito.any());
-            Mockito.verify(mockFeedRepository, Mockito.times(0)).save(Mockito.any());
+                // then
+                Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
+                Mockito.verify(mockRecordRepository, Mockito.times(0)).save(Mockito.any());
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).save(Mockito.any());
 
-            Assertions.assertEquals(serviceResult.getResult(), ServiceResult.FAIL);
+                Assertions.assertEquals(serviceResult.getResult(), ServiceResult.FAIL);
 
-        }
+            }
 
-        @Test
-        @Order(3)
-        @DisplayName("필요한 인자가 누락된 경우 생성되지 않아야 한다. - `musicName` 누락")
-        public void createFeedTestWithMusicNameNull() throws IOException{
-            // given
-            String mockOwnerId = "mockOwnerId";
-            String mockFeedType = "mockFeedType";
-            String mockFeedDescription = "mockFeedDescription";
-            int mockRecordDuration = 100;
-            MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
-            String mockMusicName = null;
-            String mockMusicianName = "mockMusicianName";
-            Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(Member.builder().memberId(mockOwnerId).build());
+            @Test
+            @Order(3)
+            @DisplayName("필요한 인자가 누락된 경우 생성되지 않아야 한다. - `musicName` 누락")
+            public void createFeedTestWithMusicNameNull() throws IOException{
+                // given
+                String mockOwnerId = "mockOwnerId";
+                String mockFeedType = "mockFeedType";
+                String mockFeedDescription = "mockFeedDescription";
+                int mockRecordDuration = 100;
+                MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
+                String mockMusicName = null;
+                String mockMusicianName = "mockMusicianName";
+                Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(Member.builder().memberId(mockOwnerId).build());
 
-            // when
-            ServiceResult serviceResult = feedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
+                // when
+                ServiceResult serviceResult = mockFeedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
 
-            // then
-            Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
-            Mockito.verify(mockRecordRepository, Mockito.times(0)).save(Mockito.any());
-            Mockito.verify(mockFeedRepository, Mockito.times(0)).save(Mockito.any());
+                // then
+                Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
+                Mockito.verify(mockRecordRepository, Mockito.times(0)).save(Mockito.any());
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).save(Mockito.any());
 
-            Assertions.assertEquals(serviceResult.getResult(), ServiceResult.FAIL);
+                Assertions.assertEquals(serviceResult.getResult(), ServiceResult.FAIL);
 
-        }
+            }
 
-        @Test
-        @Order(2)
-        @DisplayName("필요한 인자가 누락된 경우 생성되지 않아야 한다. - `feedType` 누락")
-        public void createFeedTestWithFeedTypeNull() throws IOException{
-            // given
-            Mockito.reset(mockRecordRepository);
-            Mockito.reset(mockFeedRepository);
+            @Test
+            @Order(2)
+            @DisplayName("필요한 인자가 누락된 경우 생성되지 않아야 한다. - `feedType` 누락")
+            public void createFeedTestWithFeedTypeNull() throws IOException{
+                // given
+                Mockito.reset(mockRecordRepository);
+                Mockito.reset(mockFeedRepository);
 
-            String mockOwnerId = "mockOwnerId";
-            String mockFeedType = null;
-            String mockFeedDescription = "mockFeedDescription";
-            int mockRecordDuration = 100;
-            MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
-            String mockMusicName = "mockMusicName";
-            String mockMusicianName = "mockMusicianName";
-            Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(Member.builder().memberId(mockOwnerId).build());
+                String mockOwnerId = "mockOwnerId";
+                String mockFeedType = null;
+                String mockFeedDescription = "mockFeedDescription";
+                int mockRecordDuration = 100;
+                MultipartFile mockRecordFile = new MockMultipartFile("mockRecordFile", "mockRecordFile".getBytes());
+                String mockMusicName = "mockMusicName";
+                String mockMusicianName = "mockMusicianName";
+                Mockito.when(mockMemberRepository.findByMemberId(mockOwnerId)).thenReturn(Member.builder().memberId(mockOwnerId).build());
 
-            // when
-            ServiceResult serviceResult = feedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
+                // when
+                ServiceResult serviceResult = mockFeedService.insertFeed(mockOwnerId, mockFeedType, mockFeedDescription, mockRecordDuration, mockRecordFile, mockMusicName, mockMusicianName);
 
-            // then
-            Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
-            Mockito.verify(mockRecordRepository, Mockito.times(0)).save(Mockito.any());
-            Mockito.verify(mockFeedRepository, Mockito.times(0)).save(Mockito.any());
+                // then
+                Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockOwnerId);
+                Mockito.verify(mockRecordRepository, Mockito.times(0)).save(Mockito.any());
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).save(Mockito.any());
 
-            Assertions.assertEquals(serviceResult.getResult(), ServiceResult.FAIL);
+                Assertions.assertEquals(serviceResult.getResult(), ServiceResult.FAIL);
 
+            }
         }
     }
 
     @Nested
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @DisplayName("Read 테스트 (getFeedByFeedId)")
-    class getFeedByFeedIdTest{
+    @DisplayName("Read 테스트")
+    class ReadTest{
+
         int mockFeedListSize;
         @BeforeEach
         void setUp(){
@@ -190,73 +197,501 @@ public class FeedServiceUnitTest {
             Mockito.when(mockFeedRepository.findAllByOrderByCreatedAtDesc()).thenReturn(mockFeedList);
         }
 
-        @Test
-        @Order(1)
-        @DisplayName("존재하는 모든 피드를 내림차순으로 조회할 수 있다.")
-        void getAllFeedsTest(){
-            // given
+        @Nested
+        @DisplayName("getAllFeeds")
+        class GetAllFeeds {
+            @Test
+            @Order(1)
+            @DisplayName("존재하는 모든 피드를 내림차순으로 조회할 수 있다.")
+            void getAllFeedsTest() {
+                // given
 
-            // when
-            ServiceResult dataTransferObjectList = feedService.getAllFeeds();
+                // when
+                ServiceResult dataTransferObjectList = mockFeedService.getAllFeeds();
 
-            // then
-            Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByOrderByCreatedAtDesc();
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByOrderByCreatedAtDesc();
 
-            Assertions.assertEquals(mockFeedListSize, ((List<DataTransferObject>)dataTransferObjectList.getData()).size());
+                Assertions.assertEquals(mockFeedListSize, ((List<DataTransferObject>) dataTransferObjectList.getData()).size());
+            }
         }
 
-        @Test
-        @DisplayName("`feedId`로 조회 - 유효한 피드 식별자로 특정 피드의 정보를 조회할 수 있다.")
-        void getFeedByFeedIdTest(){
-            // given
-            String mockFeedId = RandomUUIDGenerator.generate();
-            Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").build();
-            Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
+        @Nested
+        @DisplayName("getAllFeedsByMemberId")
+        class GetAllFeedsByMemberId {
+            @Test
+            @DisplayName("유효한 멤버 식별자로 특정 멤버가 생성한 모든 피드를 조회할 수 있다.")
+            void getAllFeedsByMemberIdTest() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                List<Feed> mockFeedList = List.of(
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType("mockFeedType1").description("mockFeedDescription1").musicName("mockMusicName1").musicianName("mockMusicianName1").build(),
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType("mockFeedType2").description("mockFeedDescription2").musicName("mockMusicName2").musicianName("mockMusicianName2").build(),
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType("mockFeedType3").description("mockFeedDescription3").musicName("mockMusicName3").musicianName("mockMusicianName3").build()
+                );
+                Mockito.when(mockFeedRepository.findAllByOwnerMemberId(mockMemberId)).thenReturn(mockFeedList);
 
-            // when
-            ServiceResult serviceResult = feedService.getFeedByFeedId(mockFeedId);
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByMemberId(mockMemberId);
 
-            // then
-            FeedDto feedDto = (FeedDto)serviceResult.getData();
+                // then
+                List<FeedDto> feedDtoList = (List<FeedDto>) serviceResult.getData();
 
-            Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
-            Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
-            Assertions.assertEquals(mockFeedId, feedDto.getFeedId());
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByOwnerMemberId(mockMemberId);
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals(mockFeedList.size(), feedDtoList.size());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 멤버 식별자의 경우 조회할 수 없다.")
+            void getAllFeedsByMemberIdTestWithNotExistsMemberId() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Mockito.when(mockFeedRepository.findAllByOwnerMemberId(mockMemberId)).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByOwnerMemberId(mockMemberId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Feeds not found for memberId: " + mockMemberId, serviceResult.getMessage());
+            }
+
+            @Test
+            @DisplayName("멤버 식별자가 누락된 경우 조회할 수 없다.")
+            void getAllFeedsByMemberIdTestWithMemberIdNull() {
+                // given
+                String mockMemberId = null;
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByMemberId(mockMemberId);
+
+                // then
+                List<FeedDto> feedDtoList = (List<FeedDto>) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findAllByOwnerMemberId(mockMemberId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("MemberId is null", serviceResult.getMessage());
+            }
         }
 
-        @Test
-        @DisplayName("`feedId`로 조회 - 존재하지 않는 피드 식별자의 경우 조회할 수 없다.")
-        void getFeedByFeedIdTestWithNotExistsFeedId(){
-            // given
-            String mockFeedId = RandomUUIDGenerator.generate();
-            Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").build();
-            Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(null);
+        @Nested
+        @DisplayName("getAllFeedsByFeedType")
+        class GetAllFeedsByFeedType {
+            @Test
+            @DisplayName("유효한 피드 타입으로 특정 타입의 모든 피드를 조회할 수 있다.")
+            void getAllFeedsByFeedTypeTest() {
+                // given
+                String mockFeedType = "mockFeedType";
+                List<Feed> mockFeedList = List.of(
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType(mockFeedType).description("mockFeedDescription1").musicName("mockMusicName1").musicianName("mockMusicianName1").build(),
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType(mockFeedType).description("mockFeedDescription2").musicName("mockMusicName2").musicianName("mockMusicianName2").build(),
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType(mockFeedType).description("mockFeedDescription3").musicName("mockMusicName3").musicianName("mockMusicianName3").build()
+                );
+                Mockito.when(mockFeedRepository.findAllByFeedType(mockFeedType)).thenReturn(mockFeedList);
 
-            // when
-            ServiceResult serviceResult = feedService.getFeedByFeedId(mockFeedId);
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByFeedType(mockFeedType);
 
-            // then
-            FeedDto feedDto = (FeedDto)serviceResult.getData();
+                // then
+                List<FeedDto> feedDtoList = (List<FeedDto>) serviceResult.getData();
 
-            Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
-            Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByFeedType(mockFeedType);
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals(mockFeedList.size(), feedDtoList.size());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 피드 타입의 경우 조회할 수 없다.")
+            void getAllFeedsByFeedTypeTestWithNotExistsFeedType() {
+                // given
+                String mockFeedType = "mockFeedType";
+                Mockito.when(mockFeedRepository.findAllByFeedType(mockFeedType)).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByFeedType(mockFeedType);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByFeedType(mockFeedType);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Feeds not found for feedType: " + mockFeedType, serviceResult.getMessage());
+            }
+
+            @Test
+            @DisplayName("피드 타입이 누락된 경우 조회할 수 없다.")
+            void getAllFeedsByFeedTypeTestWithFeedTypeNull() {
+                // given
+                String mockFeedType = null;
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByFeedType(mockFeedType);
+
+                // then
+                List<FeedDto> feedDtoList = (List<FeedDto>) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findAllByFeedType(mockFeedType);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("FeedType is null", serviceResult.getMessage());
+            }
         }
 
-        @Test
-        @DisplayName("`feedId`로 조회 - 피드 식별자가 누락된 경우 조회할 수 없다.")
-        void getFeedByFeedIdTestWithFeedIdNull(){
-            // given
-            String mockFeedId = null;
+        @Nested
+        @DisplayName("getFeedByFeedId")
+        class GetAllFeedsByFeedId {
+            @Test
+            @DisplayName("유효한 피드 식별자로 특정 피드의 정보를 조회할 수 있다.")
+            void getFeedByFeedIdTest() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
 
-            // when
-            ServiceResult serviceResult = feedService.getFeedByFeedId(mockFeedId);
+                // when
+                ServiceResult serviceResult = mockFeedService.getFeedByFeedId(mockFeedId);
 
-            // then
-            FeedDto feedDto = (FeedDto)serviceResult.getData();
+                // then
+                FeedDto feedDto = (FeedDto) serviceResult.getData();
 
-            Mockito.verify(mockFeedRepository, Mockito.times(0)).findByFeedId(mockFeedId);
-            Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals(mockFeedId, feedDto.getFeedId());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 피드 식별자의 경우 조회할 수 없다.")
+            void getFeedByFeedIdTestWithNotExistsFeedId() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getFeedByFeedId(mockFeedId);
+
+                // then
+                FeedDto feedDto = (FeedDto) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+            }
+
+            @Test
+            @DisplayName("피드 식별자가 누락된 경우 조회할 수 없다.")
+            void getFeedByFeedIdTestWithFeedIdNull() {
+                // given
+                String mockFeedId = null;
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getFeedByFeedId(mockFeedId);
+
+                // then
+                FeedDto feedDto = (FeedDto) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+            }
+        }
+
+        @Nested
+        @DisplayName("getInteractionFeedsByMemberId")
+        class GetInteractionFeedsByMemberId {
+            @Test
+            @DisplayName("유효한 멤버 식별자로 특정 멤버가 좋아요한 모든 피드를 조회할 수 있다.")
+            void getInteractionFeedsByMemberIdTest() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                List<Feed> mockFeedList = List.of(
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType("mockFeedType1").description("mockFeedDescription1").musicName("mockMusicName1").musicianName("mockMusicianName1").build(),
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType("mockFeedType2").description("mockFeedDescription2").musicName("mockMusicName2").musicianName("mockMusicianName2").build(),
+                        Feed.builder().feedId(RandomUUIDGenerator.generate()).feedType("mockFeedType3").description("mockFeedDescription3").musicName("mockMusicName3").musicianName("mockMusicianName3").build()
+                );
+                Mockito.when(mockFeedRepository.findAllByOwnerMemberId(mockMemberId)).thenReturn(mockFeedList);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByMemberId(mockMemberId);
+
+                // then
+                List<FeedDto> feedDtoList = (List<FeedDto>) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByOwnerMemberId(mockMemberId);
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals(mockFeedList.size(), feedDtoList.size());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 멤버 식별자의 경우 조회할 수 없다.")
+            void getInteractionFeedsByMemberIdTestWithNotExistsMemberId() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Mockito.when(mockFeedRepository.findAllByOwnerMemberId(mockMemberId)).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findAllByOwnerMemberId(mockMemberId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Feeds not found for memberId: " + mockMemberId, serviceResult.getMessage());
+            }
+
+            @Test
+            @DisplayName("멤버 식별자가 누락된 경우 조회할 수 없다.")
+            void getInteractionFeedsByMemberIdTestWithMemberIdNull() {
+                // given
+                String mockMemberId = null;
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getAllFeedsByMemberId(mockMemberId);
+
+                // then
+                List<FeedDto> feedDtoList = (List<FeedDto>) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findAllByOwnerMemberId(mockMemberId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("MemberId is null", serviceResult.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("getFeedOwnerMemberIdByFeedId")
+        class GetFeedOwnerMemberIdByFeedId {
+            @Test
+            @DisplayName("유효한 피드 식별자로 특정 피드의 주인 멤버 식별자를 조회할 수 있다.")
+            void getFeedOwnerMemberIdByFeedIdTest() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").owner(Member.builder().memberId(mockMemberId).build()).build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getFeedOwnerMemberIdByFeedId(mockFeedId);
+
+                // then
+                String ownerId = (String) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals(mockMemberId, ownerId);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 피드 식별자의 경우 조회할 수 없다.")
+            void getFeedOwnerMemberIdByFeedIdTestWithNotExistsFeedId() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getFeedOwnerMemberIdByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Feed Not Found", serviceResult.getMessage());
+            }
+
+            @Test
+            @DisplayName("피드 식별자가 누락된 경우 조회할 수 없다.")
+            void getFeedOwnerMemberIdByFeedIdTestWithFeedIdNull() {
+                // given
+                String mockFeedId = null;
+
+                // when
+                ServiceResult serviceResult = mockFeedService.getFeedOwnerMemberIdByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("FeedId is null", serviceResult.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("getRecordByFeedId")
+        class GetRecordByFeedId {
+            @Test
+            @DisplayName("유효한 피드 식별자로 특정 피드의 녹음 파일의 세부 정보를 조회할 수 있다.")
+            void getRecordByFeedIdTest() {
+                // given
+                String mockFeedId = "mockFeedId";
+                Record mockRecord = Record.builder().recordId("mockRecordId").recordFileType("mockRecordFileType").recordFileSize(100).recordDuration(100).recordRawData("mockRecordRawData".getBytes()).build();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").owner(Member.builder().memberId("mockMemberId").build()).record(mockRecord).build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
+
+                // when
+                RecordResponseBody serviceResult = mockFeedService.getRecordByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(2)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(Status.OK.getStatusCode(), serviceResult.getStatusCode());
+                Assertions.assertEquals("Record found", serviceResult.getMessage());
+                Assertions.assertEquals(mockRecord.getRecordId(), serviceResult.getRecordId());
+                Assertions.assertEquals(mockRecord.getRecordFileSize(), serviceResult.getRecordFileSize());
+                Assertions.assertEquals(mockRecord.getRecordDuration(), serviceResult.getRecordDuration());
+                Assertions.assertEquals(mockRecord.getRecordFileType(), serviceResult.getRecordFileType());
+                Assertions.assertEquals(mockRecord.getRecordRawData(), serviceResult.getRecordRawData());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 피드 식별자의 경우 조회할 수 없다.")
+            void getRecordByFeedIdTestWithNotExistsFeedId() {
+                // given
+                String mockFeedId = "mockFeedId";
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(null);
+
+                // when
+                RecordResponseBody serviceResult = mockFeedService.getRecordByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(2)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(Status.NOT_FOUND.getStatusCode(), serviceResult.getStatusCode());
+                Assertions.assertEquals("Feed not found", serviceResult.getMessage());
+            }
+
+            @Test
+            @DisplayName("피드 식별자가 누락된 경우 조회할 수 없다.")
+            void getRecordByFeedIdTestWithFeedIdNull() {
+                // given
+                String mockFeedId = null;
+
+                // when
+                RecordResponseBody serviceResult = mockFeedService.getRecordByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), serviceResult.getStatusCode());
+                Assertions.assertEquals("FeedId is null", serviceResult.getMessage());
+            }
         }
     }
 
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Update 테스트")
+    class UpdateTest {
+        @Nested
+        @DisplayName("feedViewCountUp")
+        class FeedViewCountUp{
+            @Test
+            @DisplayName("유효한 피드 식별자로 특정 피드의 조회수를 1 증가시킬 수 있다.")
+            void feedViewCountUpTest() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
+                int mockViewCount = mockFeed.getViewCount();
+
+                // when
+                ServiceResult serviceResult = mockFeedService.feedViewCountUp(mockFeedId);
+
+                // then
+                int viewCount = (int) serviceResult.getData();
+
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals(mockViewCount+1, viewCount);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 피드 식별자의 경우 조회수를 증가시킬 수 없다.")
+            void feedViewCountUpTestWithNotExistsFeedId() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.feedViewCountUp(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Feed Not Found", serviceResult.getMessage());
+            }
+
+            @Test
+            @DisplayName("피드 식별자가 누락된 경우 조회수를 증가시킬 수 없다.")
+            void feedViewCountUpTestWithFeedIdNull() {
+                // given
+                String mockFeedId = null;
+
+                // when
+                ServiceResult serviceResult = mockFeedService.feedViewCountUp(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("FeedId is null", serviceResult.getMessage());
+            }
+
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Delete 테스트")
+    class DeleteTest {
+        @Nested
+        @DisplayName("deleteFeedByFeedId")
+        class DeleteFeedByFeedId {
+            @Test
+            @DisplayName("유효한 피드 식별자로 특정 피드를 삭제할 수 있다.")
+            void deleteFeedByFeedIdTest() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").description("mockFeedDescription").musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.deleteFeedByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Mockito.verify(mockInteractionService, Mockito.times(1)).deleteInterationsByFeedId(mockFeedId);
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).deleteByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 피드 식별자의 경우 삭제할 수 없다.")
+            void deleteFeedByFeedIdTestWithNotExistsFeedId() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockFeedService.deleteFeedByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(1)).findByFeedId(mockFeedId);
+                Mockito.verify(mockInteractionService, Mockito.times(0)).deleteInterationsByFeedId(mockFeedId);
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).deleteByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Feed Not Found", serviceResult.getMessage());
+            }
+
+            @Test
+            @DisplayName("피드 식별자가 누락된 경우 삭제할 수 없다.")
+            void deleteFeedByFeedIdTestWithFeedIdNull() {
+                // given
+                String mockFeedId = null;
+
+                // when
+                ServiceResult serviceResult = mockFeedService.deleteFeedByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).findByFeedId(mockFeedId);
+                Mockito.verify(mockInteractionService, Mockito.times(0)).deleteInterationsByFeedId(mockFeedId);
+                Mockito.verify(mockFeedRepository, Mockito.times(0)).deleteByFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Bad request, feedId is null", serviceResult.getMessage());
+            }
+
+
+        }
+    }
 }

--- a/src/test/java/com/teamseven/MusicVillain/FeedServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/FeedServiceUnitTest.java
@@ -694,4 +694,58 @@ public class FeedServiceUnitTest {
 
         }
     }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("기타 테스트")
+    class AdditionalTest {
+        @Nested
+        @DisplayName("checkIsValidMemberId")
+        class CheckIsValidMemberId {
+            @Test
+            @DisplayName("유효한 멤버 식별자인 경우 true를 반환한다.")
+            void checkIsValidMemberIdTest() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Mockito.when(mockMemberRepository.findByMemberId(mockMemberId)).thenReturn(Member.builder().memberId(mockMemberId).build());
+
+                // when
+                boolean result = mockFeedService.checkIsValidMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockMemberId);
+                Assertions.assertTrue(result);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 멤버 식별자인 경우 false를 반환한다.")
+            void checkIsValidMemberIdTestWithNotExistsMemberId() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Mockito.when(mockMemberRepository.findByMemberId(mockMemberId)).thenReturn(null);
+
+                // when
+                boolean result = mockFeedService.checkIsValidMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockMemberRepository, Mockito.times(1)).findByMemberId(mockMemberId);
+                Assertions.assertFalse(result);
+            }
+
+            @Test
+            @DisplayName("멤버 식별자가 누락된 경우 false를 반환한다.")
+            void checkIsValidMemberIdTestWithMemberIdNull() {
+                // given
+                String mockMemberId = null;
+
+                // when
+                boolean result = mockFeedService.checkIsValidMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockMemberRepository, Mockito.times(0)).findByMemberId(mockMemberId);
+                Assertions.assertFalse(result);
+            }
+        }
+    }
 }

--- a/src/test/java/com/teamseven/MusicVillain/InteractionServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/InteractionServiceUnitTest.java
@@ -9,7 +9,7 @@ import com.teamseven.MusicVillain.Interaction.InteractionRepository;
 import com.teamseven.MusicVillain.Interaction.InteractionService;
 import com.teamseven.MusicVillain.Member.Member;
 import com.teamseven.MusicVillain.Member.MemberRepository;
-import com.teamseven.MusicVillain.Notification.NotificaitonRepository;
+import com.teamseven.MusicVillain.Notification.NotificationRepository;
 import com.teamseven.MusicVillain.Notification.Notification;
 import com.teamseven.MusicVillain.Utils.RandomUUIDGenerator;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +41,7 @@ public class InteractionServiceUnitTest {
     FeedRepository mockFeedRepository;
 
     @Mock
-    NotificaitonRepository mockNotificaitonRepository;
+    NotificationRepository mockNotificationRepository;
 
     @InjectMocks
     InteractionService mockInteractionService;
@@ -82,7 +82,7 @@ public class InteractionServiceUnitTest {
                         .ownerRead(Notification.NOTIFICATION_UNREAD)
                         .createdAt(LocalDateTime.now())
                         .build();
-                Mockito.when(mockNotificaitonRepository.save(mockNotification)).thenReturn(mockNotification);
+                Mockito.when(mockNotificationRepository.save(mockNotification)).thenReturn(mockNotification);
 
                 // when
                 ServiceResult serviceResult = mockInteractionService.insertInteraction(mockInteractionCreationRequestBody);
@@ -97,7 +97,7 @@ public class InteractionServiceUnitTest {
                 Assertions.assertEquals(mockMember, capturedInteraction.getInteractionMember());
 
                 ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).save(notificationCaptor.capture());
+                Mockito.verify(mockNotificationRepository, Mockito.times(1)).save(notificationCaptor.capture());
                 Notification capturedNotification = notificationCaptor.getValue();
                 Assertions.assertEquals(mockFeed.getOwner(), capturedNotification.getOwner());
                 Assertions.assertEquals(Notification.NOTIFICATION_UNREAD, capturedNotification.getOwnerRead());
@@ -133,7 +133,7 @@ public class InteractionServiceUnitTest {
                 Assertions.assertEquals(mockFeed, capturedInteraction.getInteractionFeed());
                 Assertions.assertEquals(mockMember, capturedInteraction.getInteractionMember());
 
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(capturedInteraction);
+                Mockito.verify(mockNotificationRepository, Mockito.times(1)).deleteByInteraction(capturedInteraction);
 
                 Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
                 Assertions.assertEquals("Interaction deleted", serviceResult.getMessage());
@@ -160,7 +160,7 @@ public class InteractionServiceUnitTest {
                 // then
                 Mockito.verify(mockInteractionRepository, Mockito.times(0)).findByInteractionMemberAndInteractionFeed(mockMember, mockFeed);
                 Mockito.verify(mockInteractionRepository, Mockito.times(0)).save(Mockito.any(Interaction.class));
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).save(Mockito.any(Notification.class));
+                Mockito.verify(mockNotificationRepository, Mockito.times(0)).save(Mockito.any(Notification.class));
 
                 Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
                 Assertions.assertEquals("Member or Feed not found", serviceResult.getMessage());
@@ -419,9 +419,9 @@ public class InteractionServiceUnitTest {
 
                 // then
                 Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionFeedFeedId(mockFeedId);
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(0));
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(1));
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(2));
+                Mockito.verify(mockNotificationRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(0));
+                Mockito.verify(mockNotificationRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(1));
+                Mockito.verify(mockNotificationRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(2));
                 Mockito.verify(mockInteractionRepository, Mockito.times(1)).deleteByInteractionFeedFeedId(mockFeedId);
             }
 
@@ -438,7 +438,7 @@ public class InteractionServiceUnitTest {
 
                 // then
                 Mockito.verify(mockInteractionRepository, Mockito.times(0)).findByInteractionFeedFeedId(mockFeedId);
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
+                Mockito.verify(mockNotificationRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
                 Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionFeedFeedId(mockFeedId);
             }
 
@@ -457,7 +457,7 @@ public class InteractionServiceUnitTest {
 
                 // then
                 Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionFeedFeedId(mockFeedId);
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
+                Mockito.verify(mockNotificationRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
                 Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionFeedFeedId(mockFeedId);
             }
 
@@ -472,7 +472,7 @@ public class InteractionServiceUnitTest {
 
                 // then
                 Mockito.verify(mockInteractionRepository, Mockito.times(0)).findByInteractionFeedFeedId(mockFeedId);
-                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
+                Mockito.verify(mockNotificationRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
                 Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionFeedFeedId(mockFeedId);
             }
         }

--- a/src/test/java/com/teamseven/MusicVillain/InteractionServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/InteractionServiceUnitTest.java
@@ -1,0 +1,480 @@
+package com.teamseven.MusicVillain;
+
+import com.teamseven.MusicVillain.Dto.RequestBody.InteractionCreationRequestBody;
+import com.teamseven.MusicVillain.Dto.ServiceResult;
+import com.teamseven.MusicVillain.Feed.Feed;
+import com.teamseven.MusicVillain.Feed.FeedRepository;
+import com.teamseven.MusicVillain.Interaction.Interaction;
+import com.teamseven.MusicVillain.Interaction.InteractionRepository;
+import com.teamseven.MusicVillain.Interaction.InteractionService;
+import com.teamseven.MusicVillain.Member.Member;
+import com.teamseven.MusicVillain.Member.MemberRepository;
+import com.teamseven.MusicVillain.Notification.NotificaitonRepository;
+import com.teamseven.MusicVillain.Notification.Notification;
+import com.teamseven.MusicVillain.Utils.RandomUUIDGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@SpringBootTest
+@DisplayName("InteractionService 단위 테스트")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Slf4j
+public class InteractionServiceUnitTest {
+    @Mock
+    InteractionRepository mockInteractionRepository;
+
+    @Mock
+    MemberRepository mockMemberRepository;
+
+    @Mock
+    FeedRepository mockFeedRepository;
+
+    @Mock
+    NotificaitonRepository mockNotificaitonRepository;
+
+    @InjectMocks
+    InteractionService mockInteractionService;
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Create 테스트")
+    class CreateTest{
+        @Nested
+        @DisplayName("insertInteraction")
+        class InsertInteraction{
+            @Test
+            @DisplayName("정상적인 요청이고, 해당 멤버가 해당 피드에 좋아요를 한 적 없다면, 좋아요로 동작")
+            void insertInteractionTestWithNotExistsInteraction(){
+                // given
+                InteractionCreationRequestBody mockInteractionCreationRequestBody = InteractionCreationRequestBody.builder()
+                        .feedId(RandomUUIDGenerator.generate())
+                        .memberId(RandomUUIDGenerator.generate())
+                        .build();
+                Member mockMember = Member.builder().memberId(mockInteractionCreationRequestBody.getMemberId()).userId(RandomUUIDGenerator.generate()).userInfo("mockUserInfo").name("mockName").email("mockEmail").role("mockRole").createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).lastLoginAt(LocalDateTime.now()).providerType("mockProviderType").build();
+                Feed mockFeed = Feed.builder().feedId(mockInteractionCreationRequestBody.getFeedId()).feedType("mockFeedType").owner(mockMember).record(null).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).description("mockDescription").viewCount(0).musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockInteractionRepository.findByInteractionMemberAndInteractionFeed(mockMember, mockFeed)).thenReturn(null);
+                Mockito.when(mockMemberRepository.findByMemberId(mockInteractionCreationRequestBody.getMemberId())).thenReturn(mockMember);
+                Mockito.when(mockFeedRepository.findByFeedId(mockInteractionCreationRequestBody.getFeedId())).thenReturn(mockFeed);
+
+                String mockInteractionId = UUID.randomUUID().toString().replace("-", "");
+                Interaction mockInteraction = Interaction.builder()
+                        .interactionId(mockInteractionId)
+                        .interactionFeed(mockFeed)
+                        .interactionMember(mockMember)
+                        .build();
+                Mockito.when(mockInteractionRepository.save(mockInteraction)).thenReturn(mockInteraction);
+                Notification mockNotification = Notification.builder()
+                        .notificationId(RandomUUIDGenerator.generate())
+                        .interaction(mockInteraction)
+                        .owner(mockFeed.getOwner())
+                        .ownerRead(Notification.NOTIFICATION_UNREAD)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                Mockito.when(mockNotificaitonRepository.save(mockNotification)).thenReturn(mockNotification);
+
+                // when
+                ServiceResult serviceResult = mockInteractionService.insertInteraction(mockInteractionCreationRequestBody);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionMemberAndInteractionFeed(mockMember, mockFeed);
+
+                ArgumentCaptor<Interaction> interactionCaptor = ArgumentCaptor.forClass(Interaction.class);
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).save(interactionCaptor.capture());
+                Interaction capturedInteraction = interactionCaptor.getValue();
+                Assertions.assertEquals(mockFeed, capturedInteraction.getInteractionFeed());
+                Assertions.assertEquals(mockMember, capturedInteraction.getInteractionMember());
+
+                ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).save(notificationCaptor.capture());
+                Notification capturedNotification = notificationCaptor.getValue();
+                Assertions.assertEquals(mockFeed.getOwner(), capturedNotification.getOwner());
+                Assertions.assertEquals(Notification.NOTIFICATION_UNREAD, capturedNotification.getOwnerRead());
+
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals("Interaction created", serviceResult.getMessage());
+                Assertions.assertNotNull(serviceResult.getData());
+            }
+
+            @Test
+            @DisplayName("정상적인 요청이고, 해당 멤버가 해당 피드에 좋아요를 한 적 있다면, 좋아요 취소로 동작")
+            void insertInteractionTestWithExistsInteraction(){
+                // given
+                InteractionCreationRequestBody mockInteractionCreationRequestBody = InteractionCreationRequestBody.builder()
+                        .feedId(RandomUUIDGenerator.generate())
+                        .memberId(RandomUUIDGenerator.generate())
+                        .build();
+                Member mockMember = Member.builder().memberId(mockInteractionCreationRequestBody.getMemberId()).userId(RandomUUIDGenerator.generate()).userInfo("mockUserInfo").name("mockName").email("mockEmail").role("mockRole").createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).lastLoginAt(LocalDateTime.now()).providerType("mockProviderType").build();
+                Feed mockFeed = Feed.builder().feedId(mockInteractionCreationRequestBody.getFeedId()).feedType("mockFeedType").owner(mockMember).record(null).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).description("mockDescription").viewCount(0).musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockInteractionRepository.findByInteractionMemberAndInteractionFeed(mockMember, mockFeed)).thenReturn(Interaction.builder().interactionId(RandomUUIDGenerator.generate()).interactionFeed(mockFeed).interactionMember(mockMember).build());
+                Mockito.when(mockMemberRepository.findByMemberId(mockInteractionCreationRequestBody.getMemberId())).thenReturn(mockMember);
+                Mockito.when(mockFeedRepository.findByFeedId(mockInteractionCreationRequestBody.getFeedId())).thenReturn(mockFeed);
+
+                // when
+                ServiceResult serviceResult = mockInteractionService.insertInteraction(mockInteractionCreationRequestBody);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionMemberAndInteractionFeed(mockMember, mockFeed);
+
+                ArgumentCaptor<Interaction> interactionCaptor = ArgumentCaptor.forClass(Interaction.class);
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).delete(interactionCaptor.capture());
+                Interaction capturedInteraction = interactionCaptor.getValue();
+                Assertions.assertEquals(mockFeed, capturedInteraction.getInteractionFeed());
+                Assertions.assertEquals(mockMember, capturedInteraction.getInteractionMember());
+
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(capturedInteraction);
+
+                Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+                Assertions.assertEquals("Interaction deleted", serviceResult.getMessage());
+                Assertions.assertNull(serviceResult.getData());
+            }
+
+            @Test
+            @DisplayName("해당하는 멤버나 피드가 존재하지 않을 경우, 인터랙션을 생성할 수 없다.")
+            void insertInteractionTestWithNotExistsMemberOrFeed(){
+                // given
+                InteractionCreationRequestBody mockInteractionCreationRequestBody = InteractionCreationRequestBody.builder()
+                        .feedId(RandomUUIDGenerator.generate())
+                        .memberId(RandomUUIDGenerator.generate())
+                        .build();
+                Member mockMember = Member.builder().memberId(mockInteractionCreationRequestBody.getMemberId()).userId(RandomUUIDGenerator.generate()).userInfo("mockUserInfo").name("mockName").email("mockEmail").role("mockRole").createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).lastLoginAt(LocalDateTime.now()).providerType("mockProviderType").build();
+                Feed mockFeed = Feed.builder().feedId(mockInteractionCreationRequestBody.getFeedId()).feedType("mockFeedType").owner(mockMember).record(null).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).description("mockDescription").viewCount(0).musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockInteractionRepository.findByInteractionMemberAndInteractionFeed(mockMember, mockFeed)).thenReturn(null);
+                Mockito.when(mockMemberRepository.findByMemberId(mockInteractionCreationRequestBody.getMemberId())).thenReturn(null);
+                Mockito.when(mockFeedRepository.findByFeedId(mockInteractionCreationRequestBody.getFeedId())).thenReturn(null);
+
+                // when
+                ServiceResult serviceResult = mockInteractionService.insertInteraction(mockInteractionCreationRequestBody);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).findByInteractionMemberAndInteractionFeed(mockMember, mockFeed);
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).save(Mockito.any(Interaction.class));
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).save(Mockito.any(Notification.class));
+
+                Assertions.assertEquals(ServiceResult.FAIL, serviceResult.getResult());
+                Assertions.assertEquals("Member or Feed not found", serviceResult.getMessage());
+                Assertions.assertNull(serviceResult.getData());
+            }
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Read 테스트")
+    class ReadTest{
+
+        int mockInteractionListSize;
+        @BeforeEach
+        void setUp(){
+            Mockito.reset(mockInteractionRepository);
+
+            String interactionId1 = RandomUUIDGenerator.generate();
+            String interactionId2 = RandomUUIDGenerator.generate();
+            String interactionId3 = RandomUUIDGenerator.generate();
+
+            List<Interaction> mockInteractionList = List.of(
+                    Interaction.builder().interactionId(interactionId1).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build(),
+                    Interaction.builder().interactionId(interactionId2).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build(),
+                    Interaction.builder().interactionId(interactionId3).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build()
+            );
+            mockInteractionListSize = mockInteractionList.size();
+
+            Mockito.when(mockInteractionRepository.findAll()).thenReturn(mockInteractionList);
+        }
+        @Nested
+        @DisplayName("getAllInteractions")
+        class GetAllInteractions{
+            @Test
+            @DisplayName("존재하는 모든 인터렉션을 조회할 수 있다.")
+            void getAllInteractionsTest(){
+                // given
+
+                // when
+                List dataTransferObjectList = mockInteractionService.getAllInteractions();
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findAll();
+
+                Assertions.assertEquals(mockInteractionListSize, dataTransferObjectList.size());
+            }
+        }
+
+        @Nested
+        @DisplayName("getInteractionCountByFeedId")
+        class GetInteractionCountByFeedId{
+            @Test
+            @DisplayName("유효한 피드 식별자로 특정 피드의 인터렉션 개수를 조회할 수 있다.")
+            void getInteractionCountByFeedIdTest(){
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                int mockInteractionCount = mockInteractionRepository.countByInteractionFeedFeedId(mockFeedId);
+
+                Mockito.when(mockInteractionRepository.countByInteractionFeedFeedId(mockFeedId)).thenReturn(mockInteractionCount);
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(new Feed());  // Feed 객체를 실제 정의에 맞게 생성해 주세요.
+
+                // when
+                ServiceResult serviceResult = mockInteractionService.getInteractionCountByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(2)).countByInteractionFeedFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.success(mockInteractionCount), serviceResult);
+            }
+
+
+            @Test
+            @DisplayName("존재하지 않는 피드 식별자의 경우 조회할 수 없다.")
+            void getInteractionCountByFeedIdTestWithNotExistsFeedId(){
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                int mockInteractionCount = mockInteractionRepository.countByInteractionFeedFeedId(mockFeedId);
+                Mockito.when(mockInteractionRepository.countByInteractionFeedFeedId(mockFeedId)).thenReturn(mockInteractionCount);
+
+                // when
+                ServiceResult serviceResult = mockInteractionService.getInteractionCountByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).countByInteractionFeedFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.fail("Feed not found"), serviceResult);
+            }
+
+            @Test
+            @DisplayName("피드 식별자가 누락된 경우 조회할 수 없다.")
+            void getInteractionCountByFeedIdTestWithFeedIdNull(){
+                // given
+                String mockFeedId = null;
+
+                // when
+                ServiceResult serviceResult = mockInteractionService.getInteractionCountByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).countByInteractionFeedFeedId(mockFeedId);
+                Assertions.assertEquals(ServiceResult.fail("Feed ID is null"), serviceResult);
+            }
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Delete 테스트")
+    class DeleteTest {
+        @Nested
+        @DisplayName("deleteInteractionByInteractionId")
+        class DeleteInteractionByInteractionId {
+            @Test
+            @DisplayName("유효한 인터렉션 식별자로 인터렉션을 삭제할 수 있다.")
+            void deleteInteractionByInteractionIdTest() {
+                // given
+                String mockInteractionId = RandomUUIDGenerator.generate();
+                Interaction mockInteraction = Interaction.builder().interactionId(mockInteractionId).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build();
+                Mockito.when(mockInteractionRepository.findByInteractionId(mockInteractionId)).thenReturn(mockInteraction);
+                Feed mockFeed = mockInteraction.getInteractionFeed();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeed.getFeedId())).thenReturn(mockFeed);
+                int mockInteractionCount = mockInteractionRepository.countByInteractionFeedFeedId(mockFeed.getFeedId());
+
+                // when
+                mockInteractionService.deleteInteractionByInteractionId(mockInteractionId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionId(mockInteractionId);
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).deleteByInteractionId(mockInteractionId);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 인터렉션 식별자로 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByInteractionIdTestWithNotExistsInteractionId() {
+                // given
+                String mockInteractionId = RandomUUIDGenerator.generate();
+                Interaction mockInteraction = Interaction.builder().interactionId(mockInteractionId).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build();
+                Mockito.when(mockInteractionRepository.findByInteractionId(mockInteractionId)).thenReturn(null);
+
+                // when
+                mockInteractionService.deleteInteractionByInteractionId(mockInteractionId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionId(mockInteractionId);
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionId(mockInteractionId);
+            }
+
+            @Test
+            @DisplayName("인터렉션 식별자가 누락된 경우 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByInteractionIdTestWithInteractionIdNull() {
+                // given
+                String mockInteractionId = null;
+
+                // when
+                mockInteractionService.deleteInteractionByInteractionId(mockInteractionId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).findByInteractionId(mockInteractionId);
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionId(mockInteractionId);
+            }
+        }
+
+        @Nested
+        @DisplayName("deleteInteractionByMemberId")
+        class DeleteInteractionByMemberId {
+            @Test
+            @DisplayName("유효한 회원 식별자로 인터렉션을 삭제할 수 있다.")
+            void deleteInteractionByMemberIdTest() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Member mockMember = Member.builder().memberId(mockMemberId).userId(RandomUUIDGenerator.generate()).userInfo("mockUserInfo").name("mockName").email("mockEmail").role("mockRole").createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).lastLoginAt(LocalDateTime.now()).providerType("mockProviderType").build();
+                Mockito.when(mockMemberRepository.findByMemberId(mockMemberId)).thenReturn(mockMember);
+                List<Interaction> mockInteractionList = List.of(
+                        Interaction.builder().interactionId(RandomUUIDGenerator.generate()).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(mockMember).build(),
+                        Interaction.builder().interactionId(RandomUUIDGenerator.generate()).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(mockMember).build(),
+                        Interaction.builder().interactionId(RandomUUIDGenerator.generate()).interactionFeed(Feed.builder().feedId(RandomUUIDGenerator.generate()).build()).interactionMember(mockMember).build()
+                );
+                Mockito.when(mockInteractionRepository.findAll()).thenReturn(mockInteractionList);
+                List<String> mockInteractionIdListToDelete = mockInteractionList.stream()
+                        .filter(interaction -> interaction.getInteractionMember().getMemberId().equals(mockMemberId))
+                        .map(Interaction::getInteractionId)
+                        .collect(Collectors.toList());
+
+                // when
+                mockInteractionService.deleteInteractionByMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findAll();
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 회원 식별자로 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByMemberIdTestWithNotExistsMemberId() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Member mockMember = Member.builder().memberId(mockMemberId).userId(RandomUUIDGenerator.generate()).userInfo("mockUserInfo").name("mockName").email("mockEmail").role("mockRole").createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).lastLoginAt(LocalDateTime.now()).providerType("mockProviderType").build();
+                Mockito.when(mockMemberRepository.findByMemberId(mockMemberId)).thenReturn(null);
+
+                // when
+                mockInteractionService.deleteInteractionByMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).findAll();
+            }
+
+            @Test
+            @DisplayName("인터렉션이 없는 경우 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByMemberIdTestWithNotExistsInteraction() {
+                // given
+                String mockMemberId = RandomUUIDGenerator.generate();
+                Member mockMember = Member.builder().memberId(mockMemberId).userId(RandomUUIDGenerator.generate()).userInfo("mockUserInfo").name("mockName").email("mockEmail").role("mockRole").createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).lastLoginAt(LocalDateTime.now()).providerType("mockProviderType").build();
+                Mockito.when(mockMemberRepository.findByMemberId(mockMemberId)).thenReturn(mockMember);
+                List<Interaction> mockInteractionList = List.of();
+                Mockito.when(mockInteractionRepository.findAll()).thenReturn(mockInteractionList);
+
+                // when
+                mockInteractionService.deleteInteractionByMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findAll();
+            }
+
+            @Test
+            @DisplayName("회원 식별자가 누락된 경우 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByMemberIdTestWithMemberIdNull() {
+                // given
+                String mockMemberId = null;
+
+                // when
+                mockInteractionService.deleteInteractionByMemberId(mockMemberId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).findAll();
+            }
+        }
+
+        @Nested
+        @DisplayName("deleteInteractionByFeedId")
+        class DeleteInteractionByFeedId {
+            @Test
+            @DisplayName("유효한 피드 식별자로 인터렉션을 삭제할 수 있다.")
+            void deleteInteractionByFeedIdTest() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").owner(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).record(null).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).description("mockDescription").viewCount(0).musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
+                List<Interaction> mockInteractionList = List.of(
+                        Interaction.builder().interactionId(RandomUUIDGenerator.generate()).interactionFeed(mockFeed).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build(),
+                        Interaction.builder().interactionId(RandomUUIDGenerator.generate()).interactionFeed(mockFeed).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build(),
+                        Interaction.builder().interactionId(RandomUUIDGenerator.generate()).interactionFeed(mockFeed).interactionMember(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).build()
+                );
+                Mockito.when(mockInteractionRepository.findByInteractionFeedFeedId(mockFeedId)).thenReturn(mockInteractionList);
+
+                // when
+                mockInteractionService.deleteInterationsByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionFeedFeedId(mockFeedId);
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(0));
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(1));
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(1)).deleteByInteraction(mockInteractionList.get(2));
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).deleteByInteractionFeedFeedId(mockFeedId);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 피드 식별자로 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByFeedIdTestWithNotExistsFeedId() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").owner(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).record(null).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).description("mockDescription").viewCount(0).musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(null);
+
+                // when
+                mockInteractionService.deleteInterationsByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).findByInteractionFeedFeedId(mockFeedId);
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionFeedFeedId(mockFeedId);
+            }
+
+            @Test
+            @DisplayName("인터렉션이 없는 경우 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByFeedIdTestWithNotExistsInteraction() {
+                // given
+                String mockFeedId = RandomUUIDGenerator.generate();
+                Feed mockFeed = Feed.builder().feedId(mockFeedId).feedType("mockFeedType").owner(Member.builder().memberId(RandomUUIDGenerator.generate()).build()).record(null).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).description("mockDescription").viewCount(0).musicName("mockMusicName").musicianName("mockMusicianName").build();
+                Mockito.when(mockFeedRepository.findByFeedId(mockFeedId)).thenReturn(mockFeed);
+                List<Interaction> mockInteractionList = List.of();
+                Mockito.when(mockInteractionRepository.findByInteractionFeedFeedId(mockFeedId)).thenReturn(mockInteractionList);
+
+                // when
+                mockInteractionService.deleteInterationsByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(1)).findByInteractionFeedFeedId(mockFeedId);
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionFeedFeedId(mockFeedId);
+            }
+
+            @Test
+            @DisplayName("피드 식별자가 누락된 경우 인터렉션을 삭제할 수 없다.")
+            void deleteInteractionByFeedIdTestWithFeedIdNull() {
+                // given
+                String mockFeedId = null;
+
+                // when
+                mockInteractionService.deleteInterationsByFeedId(mockFeedId);
+
+                // then
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).findByInteractionFeedFeedId(mockFeedId);
+                Mockito.verify(mockNotificaitonRepository, Mockito.times(0)).deleteByInteraction(Mockito.any(Interaction.class));
+                Mockito.verify(mockInteractionRepository, Mockito.times(0)).deleteByInteractionFeedFeedId(mockFeedId);
+            }
+        }
+    }
+}

--- a/src/test/java/com/teamseven/MusicVillain/MemberServiceTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/MemberServiceTest.java
@@ -169,29 +169,54 @@ public class MemberServiceTest {
         }
 
 
+//        @Test
+//        @Order(2)
+//        @DisplayName("회원 닉네임 수정 - 유효한 닉네임")
+//        void memberNicknameModifyTestWithValidToken() {
+//
+//            String originalNickname = testMember.getName();
+//            log.info("originalNickname: {}", originalNickname);
+//            String nicknameToModify = originalNickname+"Modified";
+//            log.info("nicknameToModify: {}", nicknameToModify);
+//
+//            // when
+//            ServiceResult serviceResult = memberService.modifyMemberNickname(testMember.getMemberId(), nicknameToModify);
+//
+//            // then
+//            Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
+//            Assertions.assertEquals(nicknameToModify,
+//                    memberRepository.findByMemberId(testMember.getMemberId()).getName());
+//
+//            log.info("\n" +
+//                    "\t* expected: {}\n" +
+//                    "\t* actual: {}", nicknameToModify ,memberRepository.findByMemberId(testMember.getMemberId()).getName());
+//
+//
+//        }
+
         @Test
         @Order(2)
         @DisplayName("회원 닉네임 수정 - 유효한 닉네임")
+        @Transactional
         void memberNicknameModifyTestWithValidToken() {
-
+            // Given
             String originalNickname = testMember.getName();
             log.info("originalNickname: {}", originalNickname);
-            String nicknameToModify = originalNickname+"Modified";
+            String nicknameToModify = originalNickname + "Modified";
             log.info("nicknameToModify: {}", nicknameToModify);
 
-            // when
+            // When
             ServiceResult serviceResult = memberService.modifyMemberNickname(testMember.getMemberId(), nicknameToModify);
 
-            // then
+            // Then
             Assertions.assertEquals(ServiceResult.SUCCESS, serviceResult.getResult());
-            Assertions.assertEquals(nicknameToModify,
-                    memberRepository.findByMemberId(testMember.getMemberId()).getName());
-
+            Member updatedMember = memberRepository.findByMemberId(testMember.getMemberId());
+            Assertions.assertNotNull(updatedMember, "Updated member should not be null");
+            Assertions.assertEquals(nicknameToModify, updatedMember.getName(), "Nicknames should match");
+            Assertions.assertEquals("Nickname changed successfully", serviceResult.getData(), "Success message should match");
             log.info("\n" +
                     "\t* expected: {}\n" +
                     "\t* actual: {}", nicknameToModify ,memberRepository.findByMemberId(testMember.getMemberId()).getName());
-
-
         }
         /////////////////////////// 회원정보 수정 테스트 ///////////////////////////
 

--- a/src/test/java/com/teamseven/MusicVillain/NotificationServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/NotificationServiceUnitTest.java
@@ -1,0 +1,177 @@
+package com.teamseven.MusicVillain;
+
+import com.teamseven.MusicVillain.Dto.NotificationDto;
+import com.teamseven.MusicVillain.Dto.ServiceResult;
+import com.teamseven.MusicVillain.Interaction.Interaction;
+import com.teamseven.MusicVillain.Member.Member;
+import com.teamseven.MusicVillain.Member.MemberRepository;
+import com.teamseven.MusicVillain.Notification.Notification;
+import com.teamseven.MusicVillain.Notification.NotificationRepository;
+import com.teamseven.MusicVillain.Notification.NotificationService;
+import com.teamseven.MusicVillain.Utils.RandomUUIDGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SpringBootTest
+@DisplayName("NotificationService 단위 테스트")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Slf4j
+public class NotificationServiceUnitTest {
+    @Mock
+    MemberRepository mockMemberRepository;
+
+    @Mock
+    NotificationRepository mockNotificationRepository;
+
+    @InjectMocks
+    NotificationService mockNotificationService;
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Read 테스트")
+    class ReadTest {
+        @Nested
+        @DisplayName("getNotificationsByOwnerMemberID")
+        class GetNotificationsByOwnerMemberID {
+
+            String memberId;
+            Member mockMember;
+            int mockNotificationListSize;
+            List<Notification> mockNotificationList;
+
+            @BeforeEach
+            void setUp() {
+                memberId = "someMemberId";
+                mockMember = Member.builder().memberId(memberId).build();
+
+                mockNotificationList = List.of(
+                        Notification.builder().notificationId("notificationId1").owner(mockMember).interaction(Interaction.builder().interactionId("interactionId1").build()).ownerRead(Notification.NOTIFICATION_UNREAD).createdAt(LocalDateTime.now()).build(),
+                        Notification.builder().notificationId("notificationId2").owner(mockMember).interaction(Interaction.builder().interactionId("interactionId2").build()).ownerRead(Notification.NOTIFICATION_UNREAD).createdAt(LocalDateTime.now()).build()
+                );
+
+                mockNotificationListSize = mockNotificationList.size();
+
+                Mockito.when(mockMemberRepository.findByMemberId(memberId)).thenReturn(mockMember);
+                Mockito.when(mockNotificationRepository.findByOwnerMemberId(memberId)).thenReturn(mockNotificationList);
+            }
+
+            @Test
+            @DisplayName("유효한 멤버 식별자로 특정 멤버의 모든 알림을 조회할 수 있다.")
+            void getNotificationsByOwnerMemberIDTest() {
+                // Execute
+                var result = mockNotificationService.getNotificaitonsByOwnerMemberID(memberId);
+
+                // Verify
+                Assertions.assertEquals(ServiceResult.SUCCESS, result.getResult());
+                Assertions.assertEquals(mockNotificationListSize, ((List<NotificationDto>) result.getData()).size());
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 멤버 식별자로 특정 멤버의 모든 알림을 조회할 수 없다.")
+            void getNotificationsByOwnerMemberIDTestWithNotExistsMemberId(){
+                // given
+                String memberId = "someMemberId";
+                Member mockMember = Member.builder().memberId(memberId).build();
+
+                Mockito.when(mockMemberRepository.findByMemberId(memberId)).thenReturn(null);
+
+                // when
+                var result = mockNotificationService.getNotificaitonsByOwnerMemberID(memberId);
+
+                // then
+                Assertions.assertEquals(ServiceResult.FAIL, result.getResult());
+                Assertions.assertEquals("Member not found", result.getMessage());
+            }
+
+            @Test
+            @DisplayName("알림이 없는 멤버의 알림을 조회하면 fail을 반환한다.")
+            void getNotificationsByOwnerMemberIDTestWithNotExistsNotification(){
+                // given
+                String memberId = "someMemberId";
+                Member mockMember = Member.builder().memberId(memberId).build();
+
+                Mockito.when(mockMemberRepository.findByMemberId(memberId)).thenReturn(mockMember);
+                Mockito.when(mockNotificationRepository.findByOwnerMemberId(memberId)).thenReturn(null);
+
+                // when
+                var result = mockNotificationService.getNotificaitonsByOwnerMemberID(memberId);
+
+                // then
+                Assertions.assertEquals(ServiceResult.FAIL, result.getResult());
+                Assertions.assertEquals("Notification not found", result.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Update 테스트")
+    class UpdateTest {
+        @Nested
+        @DisplayName("readNotification")
+        class ReadNotification {
+            @Test
+            @DisplayName("유효한 알림 식별자로 알림을 읽음 상태로 변경할 수 있다.")
+            void readNotificationTest(){
+                // given
+                String notificationId = RandomUUIDGenerator.generate();
+                Notification mockNotification = Notification.builder().notificationId(notificationId).ownerRead(Notification.NOTIFICATION_UNREAD).build();
+
+                Mockito.when(mockNotificationRepository.findByNotificationId(notificationId)).thenReturn(mockNotification);
+
+                // when
+                var result = mockNotificationService.readNotification(notificationId);
+
+                // then
+                Assertions.assertEquals(ServiceResult.SUCCESS, result.getResult());
+                Assertions.assertEquals(Notification.NOTIFICATION_READ, mockNotification.ownerRead);
+                Assertions.assertEquals("Notification read successfully", result.getMessage());
+            }
+
+            @Test
+            @DisplayName("유효하지 않은 알림 식별자로 알림을 읽음 상태로 변경할 수 없다.")
+            void readNotificationTestWithNotExistsNotificationId(){
+                // given
+                String notificationId = RandomUUIDGenerator.generate();
+                Notification mockNotification = Notification.builder().notificationId(notificationId).ownerRead(Notification.NOTIFICATION_UNREAD).build();
+
+                Mockito.when(mockNotificationRepository.findByNotificationId(notificationId)).thenReturn(null);
+
+                // when
+                var result = mockNotificationService.readNotification(notificationId);
+
+                // then
+                Assertions.assertEquals(ServiceResult.FAIL, result.getResult());
+                Assertions.assertEquals("Notification not found", result.getMessage());
+            }
+
+            @Test
+            @DisplayName("이미 읽음 상태인 알림을 다시 읽음 상태로 변경할 수 없다.")
+            void readNotificationTestWithAlreadyReadNotification(){
+                // given
+                String notificationId = RandomUUIDGenerator.generate();
+                Notification mockNotification = Notification.builder().notificationId(notificationId).ownerRead(Notification.NOTIFICATION_READ).build();
+
+                Mockito.when(mockNotificationRepository.findByNotificationId(notificationId)).thenReturn(mockNotification);
+
+                // when
+                var result = mockNotificationService.readNotification(notificationId);
+
+                // then
+                Assertions.assertEquals(ServiceResult.FAIL, result.getResult());
+                Assertions.assertEquals("Notification already read", result.getMessage());
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/teamseven/MusicVillain/NotificationServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/NotificationServiceUnitTest.java
@@ -128,14 +128,20 @@ public class NotificationServiceUnitTest {
                 Notification mockNotification = Notification.builder().notificationId(notificationId).ownerRead(Notification.NOTIFICATION_UNREAD).build();
 
                 Mockito.when(mockNotificationRepository.findByNotificationId(notificationId)).thenReturn(mockNotification);
+                Mockito.when(mockNotificationRepository.save(Mockito.any(Notification.class)))
+                        .thenAnswer(invocation -> invocation.getArgument(0));
 
                 // when
                 var result = mockNotificationService.readNotification(notificationId);
+                System.out.println("Result: " + result);  // 로깅
 
                 // then
+                Mockito.verify(mockNotificationRepository, Mockito.times(1)).save(mockNotification);
+
+                Assertions.assertNotNull(result, "Result should not be null");
                 Assertions.assertEquals(ServiceResult.SUCCESS, result.getResult());
                 Assertions.assertEquals(Notification.NOTIFICATION_READ, mockNotification.ownerRead);
-                Assertions.assertEquals("Notification read successfully", result.getMessage());
+                Assertions.assertEquals("Notification read successfully", result.getData());
             }
 
             @Test
@@ -143,7 +149,6 @@ public class NotificationServiceUnitTest {
             void readNotificationTestWithNotExistsNotificationId(){
                 // given
                 String notificationId = RandomUUIDGenerator.generate();
-                Notification mockNotification = Notification.builder().notificationId(notificationId).ownerRead(Notification.NOTIFICATION_UNREAD).build();
 
                 Mockito.when(mockNotificationRepository.findByNotificationId(notificationId)).thenReturn(null);
 

--- a/src/test/java/com/teamseven/MusicVillain/RecordServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/RecordServiceUnitTest.java
@@ -1,0 +1,115 @@
+package com.teamseven.MusicVillain;
+
+import com.teamseven.MusicVillain.Record.Record;
+import com.teamseven.MusicVillain.Record.RecordRepository;
+import com.teamseven.MusicVillain.Record.RecordService;
+import com.teamseven.MusicVillain.Utils.RandomUUIDGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.util.List;
+
+@SpringBootTest
+@DisplayName("RecordService 단위 테스트")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@Slf4j
+public class RecordServiceUnitTest {
+    @Mock
+    RecordRepository mockRecordRepository;
+
+    @InjectMocks
+    RecordService mockRecordService;
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Read 테스트")
+    class ReadTest {
+
+        int mockRecordListSize;
+
+        @BeforeEach
+        void setUp() {
+            Mockito.reset(mockRecordRepository);
+
+            String recordId1 = RandomUUIDGenerator.generate();
+            String recordId2 = RandomUUIDGenerator.generate();
+            String recordId3 = RandomUUIDGenerator.generate();
+
+            List<Record> mockRecordList = List.of(
+                    Record.builder().recordId(recordId1).recordFileType("mockFileType").recordFileSize(100).recordDuration(100).recordRawData(new byte[100]).build(),
+                    Record.builder().recordId(recordId2).recordFileType("mockFileType").recordFileSize(100).recordDuration(100).recordRawData(new byte[100]).build(),
+                    Record.builder().recordId(recordId3).recordFileType("mockFileType").recordFileSize(100).recordDuration(100).recordRawData(new byte[100]).build()
+            );
+            mockRecordListSize = mockRecordList.size();
+
+            Mockito.when(mockRecordRepository.findAll()).thenReturn(mockRecordList);
+        }
+
+        @Nested
+        @DisplayName("getAllRecords")
+        class GetAllRecords {
+            @Test
+            @DisplayName("존재하는 모든 Record를 반환한다.")
+            void getAllRecordsTest() {
+                // given
+
+                // when
+                List dataTransferObjectList = mockRecordService.getAllRecords();
+
+                // then
+                Mockito.verify(mockRecordRepository, Mockito.times(1)).findAll();
+
+                Assertions.assertEquals(mockRecordListSize, dataTransferObjectList.size());
+            }
+        }
+
+    }
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    //@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Delete 테스트")
+    class DeleteTest {
+        @Nested
+        @DisplayName("deleteRecordByRecordId")
+        class DeleteRecordByRecordId {
+            @Test
+            @DisplayName("유효한 레코드 식별자로 레코드를 삭제할 수 있다.")
+            void deleteRecordByRecordIdTest() {
+                // given
+                String recordId = RandomUUIDGenerator.generate();
+                Mockito.when(mockRecordRepository.findByRecordId(recordId)).thenReturn(new Record()); // Mock 설정
+
+                // when
+                mockRecordService.DeleteRecordByRecordId(recordId);
+
+                // then
+                Mockito.verify(mockRecordRepository, Mockito.times(1)).findByRecordId(recordId);
+                Mockito.verify(mockRecordRepository, Mockito.times(1)).deleteByRecordId(recordId);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 레코드 식별자의 경우 조회할 수 없다.")
+            void deleteRecordByRecordIdTestWithNotExistsRecordId() {
+                // given
+                String recordId = RandomUUIDGenerator.generate();
+                Mockito.when(mockRecordRepository.findByRecordId(recordId)).thenReturn(null);
+
+                // when
+                Assertions.assertThrows(IllegalArgumentException.class, () -> {
+                    mockRecordService.DeleteRecordByRecordId(recordId);
+                });
+
+                // then
+                Mockito.verify(mockRecordRepository, Mockito.times(1)).findByRecordId(recordId);
+                Mockito.verify(mockRecordRepository, Mockito.times(0)).deleteByRecordId(recordId);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
**✅ OAuth 로그인 관련**
- 프론트엔드의 개발 편의를 위해 기존에 OAuth Redirect URI를 제한해서 사용하던 방식에서 API 클라이언트가 사용하고자 하는 URI를 파라미터로 받아서 로그인에 사용할 수 있도록 변경. *(추후 다시 제한할 예정)*

**✅ API**
- 피드 수정 API 추가

**✅ Test**
- `FeedService` 단위 테스트 추가
- `InteractionService` 단위 테스트 추가
- `RecordService` 단위 테스트 추가
- `NotificationService` 단위 테스트 추가

**✅ Swagger**
- 작성이 완료된 class에 대해서 hidden 어노테이션 삭제

**✅ Document**
- `Mermaid`로 작성한 ERD 추가(작성중)