### PR TITLE
Swagger 파일 업로드 기능, JWT 인증 기능 및 CORS 설정 추가

### DIFF
--- a/src/main/java/com/teamseven/MusicVillain/Configuration/SwaggerConfig.java
+++ b/src/main/java/com/teamseven/MusicVillain/Configuration/SwaggerConfig.java
@@ -1,0 +1,50 @@
+package com.teamseven.MusicVillain.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+//@OpenAPIDefinition(
+//        info = @Info(title = "MusicVillains API",
+//                description = "refrence for MusicVillains API",
+//                version = "v1"))
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        Info info = new Info()
+                .version("v1")
+                .title("MusicVillains API")
+                .description("refrence for MusicVillains API");
+
+        // SecuritySecheme 이름
+        String jwtSchemeName = "Access Token(JWT)";
+
+        // API호출 시 전역으로 설정한 인증정보가 요청 헤더에 포함이 되도록 설정
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식으로 설정, HTTP 외에도 APIKEY, OAUTH2, OpenIdConnect 등 지원
+                        .scheme("bearer") // bearer token 방식을 사용
+                        .bearerFormat("JWT")); // 토큰 형식을 지정하는 임의의 문자(Optional)
+
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+
+
+}

--- a/src/main/java/com/teamseven/MusicVillain/Configuration/SwaggerConfig.java
+++ b/src/main/java/com/teamseven/MusicVillain/Configuration/SwaggerConfig.java
@@ -1,20 +1,15 @@
 package com.teamseven.MusicVillain.Configuration;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import java.util.Arrays;
 
-//@OpenAPIDefinition(
-//        info = @Info(title = "MusicVillains API",
-//                description = "refrence for MusicVillains API",
-//                version = "v1"))
 @Configuration
 public class SwaggerConfig {
 
@@ -25,6 +20,7 @@ public class SwaggerConfig {
                 .version("v1")
                 .title("MusicVillains API")
                 .description("refrence for MusicVillains API");
+
 
         // SecuritySecheme 이름
         String jwtSchemeName = "Access Token(JWT)";
@@ -41,6 +37,12 @@ public class SwaggerConfig {
                         .bearerFormat("JWT")); // 토큰 형식을 지정하는 임의의 문자(Optional)
 
         return new OpenAPI()
+                .servers(Arrays.asList(
+                        new Server().url("https://musicvillains.run.goorm.io/")
+                                .description("Production Server"),
+                        new Server().url("http://localhost:8080")
+                                .description("Local Server")
+                ))
                 .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);

--- a/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
@@ -126,7 +126,7 @@ public class FeedController {
             @RequestParam("recordDuration") int recordDuration,
 //            @RequestParam("recordFile") MultipartFile recordFile,
             @Parameter(
-                    description = "파일 업로드",
+                    description = "음원 파일(`MultiPartFile`)",
                     content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
             ) @RequestPart("recordFile") MultipartFile recordFile,
             @RequestHeader HttpHeaders headers) throws IOException {
@@ -169,7 +169,16 @@ public class FeedController {
      * @param headers JWT 토큰을 포함한 헤더
      * @return [성공] 수정된 피드 정보 반환<br>[실패] 실패 메시지 반환
      */
-    @PutMapping(value = "/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "피드 수정", description =
+            "<b>Requirements</b><br>" +
+            "- `Authorization Header`에 수정하려는 피드에 대해 권한을 가진 `Access Token(JWT)`을 포함합니다.<br>"+
+            "<br>" +
+            "<b>피드 내용을 수정합니다.</b><br>" +
+            "- 수정하고자 하는 필드와 수정하려는 값(value)를 `form-data` 형태로 요청합니다.<br>" +
+            "- 피드 식별자(`feedId`)를 제외한 나머지 필드는 모두 선택적으로 수정할 수 있습니다.<br>" +
+            "- 수정하지 않는 필드의 경우 생략하여 `null`로 요청합니다.")
+    @PutMapping(value = "/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseObject modifyFeed(@RequestParam(name = "feedId", required = true) String feedId,
                                      @RequestParam(name = "feedType", required = false) String feedType,
                                      @RequestParam(name = "description", required = false) String feedDescription,
@@ -177,7 +186,7 @@ public class FeedController {
                                      @RequestParam(name = "musicianName", required = false) String musicianName,
 //                                     @RequestParam(name = "recordFile",  required = false) MultipartFile recordFile,
                                      @Parameter(
-                                             description = "파일 업로드",
+                                             description = "음원 파일(MultiPartFile)",
                                              content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
                                      ) @RequestPart("recordFile") MultipartFile recordFile,
                                      @RequestHeader HttpHeaders headers){

--- a/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Feed/FeedController.java
@@ -11,10 +11,12 @@ import com.teamseven.MusicVillain.Member.Member;
 import com.teamseven.MusicVillain.Dto.DtoTest;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -112,7 +114,7 @@ public class FeedController {
      *         [실패] 실패 메시지 반환
      * @throws IOException 파일 입출력 예외
      */
-    @PostMapping("/feeds")
+    @PostMapping(value = "/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "피드 생성", description = "새로운 피드를 생성합니다.")
     public ResponseObject createFeed(
             // MultipartFile 받으려면 @RequestParam 사용해야하므로 다음과 같이 form-data로 받도록 함.
@@ -122,7 +124,11 @@ public class FeedController {
             @RequestParam("feedType") String feedType,
             @RequestParam("description") String feedDescription,
             @RequestParam("recordDuration") int recordDuration,
-            @RequestParam("recordFile") MultipartFile recordFile,
+//            @RequestParam("recordFile") MultipartFile recordFile,
+            @Parameter(
+                    description = "파일 업로드",
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+            ) @RequestPart("recordFile") MultipartFile recordFile,
             @RequestHeader HttpHeaders headers) throws IOException {
 
         log.trace("─> [FeedController] createFeed() called");
@@ -163,13 +169,17 @@ public class FeedController {
      * @param headers JWT 토큰을 포함한 헤더
      * @return [성공] 수정된 피드 정보 반환<br>[실패] 실패 메시지 반환
      */
-    @PutMapping("/feeds")
+    @PutMapping(value = "/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseObject modifyFeed(@RequestParam(name = "feedId", required = true) String feedId,
                                      @RequestParam(name = "feedType", required = false) String feedType,
                                      @RequestParam(name = "description", required = false) String feedDescription,
                                      @RequestParam(name = "musicName", required = false) String musicName,
                                      @RequestParam(name = "musicianName", required = false) String musicianName,
-                                     @RequestParam(name = "recordFile",  required = false) MultipartFile recordFile,
+//                                     @RequestParam(name = "recordFile",  required = false) MultipartFile recordFile,
+                                     @Parameter(
+                                             description = "파일 업로드",
+                                             content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+                                     ) @RequestPart("recordFile") MultipartFile recordFile,
                                      @RequestHeader HttpHeaders headers){
 
         AuthorizationResult authResult = feedAuthManager.authorize(headers, feedId);

--- a/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Interaction/InteractionController.java
@@ -6,17 +6,16 @@ import com.teamseven.MusicVillain.Dto.ServiceResult;
 import com.teamseven.MusicVillain.Dto.ResponseBody.Status;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 @RestController
+@RequiredArgsConstructor
+@Tag(name = "인터렉션 관련 API")
 public class InteractionController {
-
+    
     private final InteractionService interactionService;
-
-    @Autowired
-    public InteractionController(InteractionService interactionService) {
-        this.interactionService = interactionService;
-    }
 
     /**
      * 상호작용 생성 | POST | /interactions

--- a/src/main/java/com/teamseven/MusicVillain/MusicVillainApplication.java
+++ b/src/main/java/com/teamseven/MusicVillain/MusicVillainApplication.java
@@ -1,6 +1,4 @@
 package com.teamseven.MusicVillain;
-import com.teamseven.MusicVillain.Utils.ENV;
-import com.teamseven.MusicVillain.Utils.FeedMockDataGenerator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/teamseven/MusicVillain/Notification/NotificationController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Notification/NotificationController.java
@@ -6,6 +6,7 @@ import com.teamseven.MusicVillain.Dto.ServiceResult;
 import com.teamseven.MusicVillain.Security.JWT.AuthorizationResult;
 import com.teamseven.MusicVillain.Security.JWT.MemberJwtAuthorizationManager;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "알림 관련 API")
 public class NotificationController {
     private final NotificationService notificationService;
     private final MemberJwtAuthorizationManager memberAuthManager;

--- a/src/main/java/com/teamseven/MusicVillain/Record/RecordController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Record/RecordController.java
@@ -2,19 +2,18 @@ package com.teamseven.MusicVillain.Record;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 @RestController
+@RequiredArgsConstructor
+@Tag(name = "음원 관련 API")
 public class RecordController {
     private final RecordService recordService;
-
-    @Autowired
-    public RecordController(RecordService recordService){
-        this.recordService = recordService;
-    }
 
     /**
      * 모든 Record 객체 조회 | GET | /records
@@ -27,7 +26,7 @@ public class RecordController {
      * @return Record 객체 리스트 반환
      */
     @GetMapping("/records")
-    @Operation(summary = "모든 Record 객체를 반환합니다.")
+    @Operation(summary = "업로드된 모든 음원 정보를 반환합니다.")
     public List<Record> records(){
         return recordService.getAllRecords();
     }

--- a/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthController.java
+++ b/src/main/java/com/teamseven/MusicVillain/Security/OAuth/OAuthController.java
@@ -6,6 +6,7 @@ import com.teamseven.MusicVillain.Dto.ServiceResult;
 import com.teamseven.MusicVillain.Security.JWT.JwtManager;
 import com.teamseven.MusicVillain.Utils.ENV;
 import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -15,8 +16,8 @@ import org.springframework.web.servlet.view.RedirectView;
 import java.util.HashMap;
 import java.util.Map;
 
-@Hidden
 @RestController
+@Tag(name = "간편 로그인 API", description = "간편 로그인 관련 API 입니다.")
 @Slf4j
 public class OAuthController {
 
@@ -34,6 +35,7 @@ public class OAuthController {
             * after test, need to change Kakao's redirect URI in com.teamseven.MusicVillain.Security.OAuth.OAuthService
          - see:
             * kakao developer's setting: https://developers.kakao.com*/
+    @Hidden
     @GetMapping("/oauth2/kakao/callback")
     public Object catchKakaoAuthenticationCodeCallBack(@RequestParam("code") String code){
         log.trace("> Enter catchKakaoAuthenticationCodeCallBack()");
@@ -63,6 +65,7 @@ public class OAuthController {
     }
 
     /* TODO: just for test */
+    @Hidden
     @GetMapping("/kakaoLoginTest")
     public RedirectView kakaoLoginPage(){
         RedirectView redirectView = new RedirectView();

--- a/src/main/java/com/teamseven/MusicVillain/Utils/FeedMockDataGenerator.java
+++ b/src/main/java/com/teamseven/MusicVillain/Utils/FeedMockDataGenerator.java
@@ -1,6 +1,7 @@
 package com.teamseven.MusicVillain.Utils;
 
 import com.teamseven.MusicVillain.Feed.FeedService;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -63,6 +64,7 @@ public class FeedMockDataGenerator {
 
 }
 
+@Hidden
 @RestController
 class TestController{
 


### PR DESCRIPTION
# 1. Swagger에서 파일 업로드 할 수 있도록 변경(#53)
파일 업로드가 필요한 API에서 **`Try it out`** 버튼 클릭하여 API 호출 시도시, 파일 선택하여 업로드 할 수 있도록 추가

### 추가된 파일 선택 버튼
<img width="721" alt="image" src="https://github.com/MusicVillains/Team7-Backend/assets/84436996/f7f7e303-6697-49e5-84ae-36c5ba27afa1">

### 파일 선택 클릭 시 선택창
<img width="971" alt="image" src="https://github.com/MusicVillains/Team7-Backend/assets/84436996/898a85d0-3ee4-4195-b177-c0765be279d0">

---

# 2. Swagger에 https 적용(#52)

현재 WebMvcConfig를 통해 모든 origin에 대해 CORS를 허용했음에도 Swagger에서 CORS가 발생하는 문제 발생

# 발견한 문제 원인
<img width="568" alt="image" src="https://github.com/MusicVillains/Team7-Backend/assets/84436996/891cdf00-fd37-49a6-9121-e94e489bd484">

API Server에 SSL이 적용되어 `https`를 사용하는데,
실제로 날아가는 request URL을 확인해보면 `http` 프로토콜을 사용한 URL로 요청해서 문제가 발생한 것으로 추정

# 해결방안
- 확인 결과 Swagger는 기본적으로 http를 사용하여 요청을 보낸다고 함
- 현재 API Server는 Reverse Proxy가 http로 요청시 별도로 https로 proxy-pass 해주는데도 불구하고 CORS 발생하는 상황 
- 로컬과 배포환경을 각각 Swagger 설정에서 서버로 추가해주고, 배포환경은 직접 https로 지정된 서버 URL를 명시해주어 해결할 예정
- SwaggerConfig 클래스에서 빈으로 등록한 OpenAPI 리턴 값에 배포환경과 로컬환경을 server로 추가

# 해결 결과

### SwaggerConfig 변경 사항
```java
/* com.teamseven.MusicVillain.Configuration.SwaggerConfig의 openAPI method*/

@Configuration
public class SwaggerConfig {
  /* 생략 */

  return new OpenAPI()
                  .servers(Arrays.asList(
                          /* `Server`: io.swagger.v3.oas.models.servers.Server */ 
                          new Server().url("https://musicvillains.run.goorm.io/")
                                  .description("Production Server"),
                          new Server().url("http://localhost:8080")
                                  .description("Local Server")
                  ))
                  .info(info)
                  .addSecurityItem(securityRequirement)
                  .components(components);

}
```

# 변경 후 결과
### 로컬과 배포 환경이 추가된 결과
<img width="435" alt="image" src="https://github.com/MusicVillains/Team7-Backend/assets/84436996/69fdcac7-7879-44ce-86a7-cd7e4e157125">


### API Server로 선택 후 API 호출 결과
<img width="604" alt="image" src="https://github.com/MusicVillains/Team7-Backend/assets/84436996/12c84617-e275-4666-8047-ea998930baca">

* https가 적용된 URL로 Request 하는 것을 볼 수 있다.

* 이전에 SSL이 적용된 배포환경(API Server)에서 Swagger 사용시 Swagger가 http 프로토콜을 기본적으로 사용하면서 발생하던 CORS 문제가 해결되어 정상적으로 호출되는 것을 볼 수 있다.

---

# 3. Swagger에 JWT 인증을 위한 Authorize 버튼 추가(#51)

### 추가된 Authorization 버튼
<img width="665" alt="image" src="https://github.com/MusicVillains/Team7-Backend/assets/84436996/b8cbe741-23af-41a1-85bb-ebaa58f98f5e">

### Authorization 클릭시 Access Token을 입력받아 해당 토큰으로 전역 인증 수행
<img width="711" alt="image" src="https://github.com/MusicVillains/Team7-Backend/assets/84436996/eae46c0b-0368-4fb3-994b-16f68a91964e">





