### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/teamseven/MusicVillain/Notification/NotificationService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Notification/NotificationService.java
@@ -35,7 +35,7 @@ public class NotificationService {
         List<Notification> notifications = notificationRepository.findByOwnerMemberId(memberId);
 
         if (notifications == null || notifications.isEmpty())
-            return ServiceResult.success("There are no notifications.");
+            return ServiceResult.of(ServiceResult.SUCCESS, "There are no notifications");
 
         List<NotificationDto> notificationDto = dtoConverter.convertToDtoList(notifications);
         return ServiceResult.success(notificationDto);
@@ -54,7 +54,7 @@ public class NotificationService {
         Notification tmpNotification = notificationRepository.findByNotificationId(notificationId);
         if (tmpNotification == null) return ServiceResult.fail("Notification not found");
         if (tmpNotification.ownerRead.equals(Notification.NOTIFICATION_READ))
-            return ServiceResult.success("Notification already read");
+            return ServiceResult.of(ServiceResult.SUCCESS, "Notification already read");
 
         tmpNotification.ownerRead = Notification.NOTIFICATION_READ;
         notificationRepository.save(tmpNotification);

--- a/src/main/java/com/teamseven/MusicVillain/Notification/NotificationService.java
+++ b/src/main/java/com/teamseven/MusicVillain/Notification/NotificationService.java
@@ -28,10 +28,15 @@ public class NotificationService {
      * @return ServiceResult 객체. 성공 또는 실패 메시지를 포함.
      */
     public ServiceResult getNotificaitonsByOwnerMemberID(String memberId){
+
         Member tmpMember =memberRepository.findByMemberId(memberId);
+
         if (tmpMember == null) return ServiceResult.fail("Member not found");
         List<Notification> notifications = notificationRepository.findByOwnerMemberId(memberId);
-        if (notifications == null || notifications.isEmpty()) return ServiceResult.fail("Notification not found");
+
+        if (notifications == null || notifications.isEmpty())
+            return ServiceResult.success("There are no notifications.");
+
         List<NotificationDto> notificationDto = dtoConverter.convertToDtoList(notifications);
         return ServiceResult.success(notificationDto);
     }
@@ -49,7 +54,7 @@ public class NotificationService {
         Notification tmpNotification = notificationRepository.findByNotificationId(notificationId);
         if (tmpNotification == null) return ServiceResult.fail("Notification not found");
         if (tmpNotification.ownerRead.equals(Notification.NOTIFICATION_READ))
-            return ServiceResult.fail("Notification already read");
+            return ServiceResult.success("Notification already read");
 
         tmpNotification.ownerRead = Notification.NOTIFICATION_READ;
         notificationRepository.save(tmpNotification);

--- a/src/test/java/com/teamseven/MusicVillain/NotificationServiceUnitTest.java
+++ b/src/test/java/com/teamseven/MusicVillain/NotificationServiceUnitTest.java
@@ -93,7 +93,7 @@ public class NotificationServiceUnitTest {
             }
 
             @Test
-            @DisplayName("알림이 없는 멤버의 알림을 조회하면 fail을 반환한다.")
+            @DisplayName("알림이 없는 멤버의 알림을 조회하면 서비스 성공을 반환하고 해당 멤버에 대한 알림이 없다는 메시지를 반환한다.")
             void getNotificationsByOwnerMemberIDTestWithNotExistsNotification(){
                 // given
                 String memberId = "someMemberId";
@@ -106,8 +106,8 @@ public class NotificationServiceUnitTest {
                 var result = mockNotificationService.getNotificaitonsByOwnerMemberID(memberId);
 
                 // then
-                Assertions.assertEquals(ServiceResult.FAIL, result.getResult());
-                Assertions.assertEquals("Notification not found", result.getMessage());
+                Assertions.assertEquals(ServiceResult.SUCCESS, result.getResult());
+                Assertions.assertEquals("There are no notifications", result.getMessage());
             }
         }
     }
@@ -161,7 +161,7 @@ public class NotificationServiceUnitTest {
             }
 
             @Test
-            @DisplayName("이미 읽음 상태인 알림을 다시 읽음 상태로 변경할 수 없다.")
+            @DisplayName("이미 읽음 상태인 알림에 대해 읽음처리를 시도할 경우 서비스 성공을 반환하고 별도로 처리하지 않는다.")
             void readNotificationTestWithAlreadyReadNotification(){
                 // given
                 String notificationId = RandomUUIDGenerator.generate();
@@ -173,7 +173,7 @@ public class NotificationServiceUnitTest {
                 var result = mockNotificationService.readNotification(notificationId);
 
                 // then
-                Assertions.assertEquals(ServiceResult.FAIL, result.getResult());
+                Assertions.assertEquals(ServiceResult.SUCCESS, result.getResult());
                 Assertions.assertEquals("Notification already read", result.getMessage());
             }
         }


### PR DESCRIPTION
**NotificationService의 일부 Response 수정**
- getNotificaitonsByOwnerMemberID(..) 메서드가 반환할 Notification이 없어도 ServiceResult를 success로 리턴하도록 변경
- readNotification(..) 메서드에서 이미 읽은 Notification에 대해 다시 읽음처리를 시도해도 ServiceResult를 success를 리턴하도록 변경

**NotificationService 응답 변경에 따라 관련 테스트코드 수정**
